### PR TITLE
Use Unparser Dialect for plan_to_sql

### DIFF
--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
-    sql::sqlparser::dialect::{Dialect, GenericDialect},
+    sql::unparser::dialect::{DefaultDialect, Dialect},
 };
 use datafusion_federation_sql::SQLExecutor;
 use futures::TryStreamExt;
@@ -96,7 +96,7 @@ impl SQLExecutor for FlightSQLExecutor {
     }
 
     fn dialect(&self) -> Arc<dyn Dialect> {
-        Arc::new(GenericDialect {})
+        Arc::new(DefaultDialect {})
     }
 }
 

--- a/sources/sql/src/connectorx/executor.rs
+++ b/sources/sql/src/connectorx/executor.rs
@@ -10,7 +10,7 @@ use datafusion::{
     physical_plan::{
         stream::RecordBatchStreamAdapter, EmptyRecordBatchStream, SendableRecordBatchStream,
     },
-    sql::sqlparser::dialect::{Dialect, GenericDialect, PostgreSqlDialect, SQLiteDialect},
+    sql::unparser::dialect::{DefaultDialect, Dialect, PostgreSqlDialect, SqliteDialect},
 };
 use futures::executor::block_on;
 use std::sync::Arc;
@@ -92,8 +92,8 @@ impl SQLExecutor for CXExecutor {
     fn dialect(&self) -> Arc<dyn Dialect> {
         match &self.conn.ty {
             SourceType::Postgres => Arc::new(PostgreSqlDialect {}),
-            SourceType::SQLite => Arc::new(SQLiteDialect {}),
-            _ => Arc::new(GenericDialect {}),
+            SourceType::SQLite => Arc::new(SqliteDialect {}),
+            _ => Arc::new(DefaultDialect {}),
         }
     }
 }

--- a/sources/sql/src/executor.rs
+++ b/sources/sql/src/executor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use core::fmt;
 use datafusion::{
     arrow::datatypes::SchemaRef, error::Result, physical_plan::SendableRecordBatchStream,
-    sql::sqlparser::dialect::Dialect,
+    sql::unparser::dialect::Dialect,
 };
 use std::sync::Arc;
 


### PR DESCRIPTION
Use the Unparser Dialect from the `unparser` module in DataFusion instead of using it from the `sqlparser-rs` project directly. Then we can call `unparser.plan_to_sql` which will generate SQL based on the Dialect we want, instead of it being generated using the Default dialect.