### PR TITLE
Fix the fallback to the table provider for supports_filters_pushdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.77"
-datafusion = "38.0.0"
-datafusion-substrait = "38.0.0"
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c533d36788eb66b5a90ce158bdad182d6b3a0da9" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", folder = "datafusion/substrait", rev = "c533d36788eb66b5a90ce158bdad182d6b3a0da9" }

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -7,7 +7,7 @@ use datafusion::{
     datasource::TableProvider,
     error::{DataFusionError, Result},
     execution::context::SessionState,
-    logical_expr::{Expr, LogicalPlan, TableSource, TableType},
+    logical_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType},
     physical_plan::ExecutionPlan,
 };
 
@@ -87,6 +87,19 @@ impl TableProvider for FederatedTableProviderAdaptor {
         }
 
         self.source.get_column_default(column)
+    }
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        if let Some(table_provider) = &self.table_provider {
+            return table_provider.supports_filters_pushdown(filters);
+        }
+
+        Ok(vec![
+            TableProviderFilterPushDown::Unsupported;
+            filters.len()
+        ])
     }
 
     // Scan is not supported; the adaptor should be replaced


### PR DESCRIPTION
Fixes the fallback to `supports_filters_pushdown` for table providers in FederatedTableProviderAdaptor