### PR TITLE
Handle table rewrites for aggregation functions

### DIFF
--- a/sources/sql/Cargo.toml
+++ b/sources/sql/Cargo.toml
@@ -26,3 +26,6 @@ tracing = "0.1.40"
 
 [features]
 connectorx = ["dep:connectorx"]
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }


### PR DESCRIPTION
Handles rewrites for aggregates like `MAX` which have a column name that embeds the table name.