### PR TITLE
Add layer to convert actual schema to expected schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.77"
+async-stream = "0.3.5"
+futures = "0.3.30"
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "4b6489ffd8d138b138c2049966b19d073867885f" }
 datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", folder = "datafusion/substrait", rev = "4b6489ffd8d138b138c2049966b19d073867885f" }

--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/lib.rs"
 [dependencies]
 async-trait.workspace = true
 datafusion.workspace = true
+async-stream.workspace = true
+futures.workspace = true
 
 [package.metadata.docs.rs]
 

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -13,6 +13,7 @@ pub use table_provider::*;
 
 mod plan_node;
 pub use plan_node::*;
+pub mod schema_cast;
 
 pub type FederationProviderRef = Arc<dyn FederationProvider>;
 pub trait FederationProvider: Send + Sync {

--- a/datafusion-federation/src/schema_cast.rs
+++ b/datafusion-federation/src/schema_cast.rs
@@ -1,0 +1,101 @@
+use async_stream::stream;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+};
+use futures::StreamExt;
+use std::any::Any;
+use std::clone::Clone;
+use std::fmt;
+use std::sync::Arc;
+
+mod record_convert;
+
+#[derive(Debug)]
+#[allow(clippy::module_name_repetitions)]
+pub struct SchemaCastScanExec {
+    input: Arc<dyn ExecutionPlan>,
+    schema: SchemaRef,
+    properties: PlanProperties,
+}
+
+impl SchemaCastScanExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, schema: SchemaRef) -> Self {
+        let eq_properties = input.equivalence_properties().clone();
+        let execution_mode = input.execution_mode();
+        let properties = PlanProperties::new(
+            eq_properties,
+            input.output_partitioning().clone(),
+            execution_mode,
+        );
+        Self {
+            input,
+            schema,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for SchemaCastScanExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SchemaCastScanExec")
+    }
+}
+
+impl ExecutionPlan for SchemaCastScanExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![Arc::clone(&self.input)]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() == 1 {
+            Ok(Arc::new(Self::new(
+                Arc::clone(&children[0]),
+                Arc::clone(&self.schema),
+            )))
+        } else {
+            Err(DataFusionError::Execution(
+                "SchemaCastScanExec expects exactly one input".to_string(),
+            ))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let mut stream = self.input.execute(partition, context)?;
+        let schema = Arc::clone(&self.schema);
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            {
+                stream! {
+                    while let Some(batch) = stream.next().await {
+                        let batch = record_convert::try_cast_to(batch?, Arc::clone(&schema));
+                        yield batch.map_err(|e| { DataFusionError::External(Box::new(e)) });
+                    }
+                }
+            },
+        )))
+    }
+}

--- a/datafusion-federation/src/schema_cast/record_convert.rs
+++ b/datafusion-federation/src/schema_cast/record_convert.rs
@@ -1,0 +1,119 @@
+use datafusion::arrow::{
+    array::{Array, RecordBatch},
+    compute::cast,
+    datatypes::SchemaRef,
+};
+use std::sync::Arc;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub enum Error {
+    UnableToConvertRecordBatch {
+        source: datafusion::arrow::error::ArrowError,
+    },
+
+    UnexpectedNumberOfColumns {
+        expected: usize,
+        found: usize,
+    },
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::UnableToConvertRecordBatch { source } => {
+                write!(f, "Unable to convert record batch: {}", source)
+            }
+            Error::UnexpectedNumberOfColumns { expected, found } => {
+                write!(
+                    f,
+                    "Unexpected number of columns. Expected: {}, Found: {}",
+                    expected, found
+                )
+            }
+        }
+    }
+}
+
+/// Cast a given record batch into a new record batch with the given schema.
+/// It assumes the record batch columns are correctly ordered.
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn try_cast_to(
+    record_batch: RecordBatch,
+    expected_schema: SchemaRef,
+) -> Result<RecordBatch> {
+    let actual_schema = record_batch.schema();
+
+    if actual_schema.fields().len() != expected_schema.fields().len() {
+        return Err(Error::UnexpectedNumberOfColumns {
+            expected: expected_schema.fields().len(),
+            found: actual_schema.fields().len(),
+        });
+    }
+
+    let cols = expected_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, expected_field)| {
+            let record_batch_col = record_batch.column(i);
+
+            return cast(&Arc::clone(record_batch_col), expected_field.data_type())
+                .map_err(|e| Error::UnableToConvertRecordBatch { source: e });
+        })
+        .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+
+    RecordBatch::try_new(expected_schema, cols)
+        .map_err(|e| Error::UnableToConvertRecordBatch { source: e })
+}
+
+#[cfg(test)]
+mod test {
+    use datafusion::arrow::{
+        array::{Int32Array, StringArray},
+        datatypes::{DataType, Field, Schema, TimeUnit},
+    };
+
+    use super::*;
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+            Field::new("c", DataType::Utf8, false),
+        ]))
+    }
+
+    fn to_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::LargeUtf8, false),
+            Field::new("c", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        ]))
+    }
+
+    fn batch_input() -> RecordBatch {
+        RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["foo", "bar", "baz"])),
+                Arc::new(StringArray::from(vec![
+                    "2024-01-13 03:18:09.000000",
+                    "2024-01-13 03:18:09",
+                    "2024-01-13 03:18:09.000",
+                ])),
+            ],
+        )
+        .expect("record batch should not panic")
+    }
+
+    #[test]
+    fn test_string_to_timestamp_conversion() {
+        let result = try_cast_to(batch_input(), to_schema()).expect("converted");
+        assert_eq!(3, result.num_rows());
+    }
+}


### PR DESCRIPTION
Handles the case where the schema returned from the federated source does not exactly match the schema DataFusion expects.

I've observed this happen when running this query:
```sql
SELECT count(1) FROM remote_table
```

DataFusion during its planning expects this is an Int64, but the remote source returned an Int32. This caused issues when decoding record batches based on the Int64 schema, since the number of bytes was incorrect.