### PR TITLE
Improve rewrite logic for expressions

### DIFF
--- a/sources/sql/Cargo.toml
+++ b/sources/sql/Cargo.toml
@@ -23,6 +23,7 @@ datafusion-federation.path = "../../datafusion-federation"
 futures = "0.3.30"
 tokio = "1.35.1"
 tracing = "0.1.40"
+regex = "1.10.5"
 
 [features]
 connectorx = ["dep:connectorx"]

--- a/sources/sql/Cargo.toml
+++ b/sources/sql/Cargo.toml
@@ -23,7 +23,6 @@ datafusion-federation.path = "../../datafusion-federation"
 futures = "0.3.30"
 tokio = "1.35.1"
 tracing = "0.1.40"
-regex = "1.10.5"
 
 [features]
 connectorx = ["dep:connectorx"]

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -182,10 +182,14 @@ fn rewrite_column_name_in_expr(
     let idx = start_pos + idx;
 
     if idx > 0 {
-        // Check if the previous character is alphabetic, underscore or period, in which case we
+        // Check if the previous character is alphabetic, numeric, underscore or period, in which case we
         // should not rewrite as it is a part of another name.
         if let Some(prev_char) = col_name.chars().nth(idx - 1) {
-            if prev_char.is_alphabetic() || prev_char == '_' || prev_char == '.' {
+            if prev_char.is_alphabetic()
+                || prev_char.is_numeric()
+                || prev_char == '_'
+                || prev_char == '.'
+            {
                 return rewrite_column_name_in_expr(
                     col_name,
                     table_ref_str,
@@ -196,10 +200,10 @@ fn rewrite_column_name_in_expr(
         }
     }
 
-    // Check if the next character is alphabetic or underscore, in which case we
+    // Check if the next character is alphabetic, numeric or underscore, in which case we
     // should not rewrite as it is a part of another name.
     if let Some(next_char) = col_name.chars().nth(idx + table_ref_str.len()) {
-        if next_char.is_alphabetic() || next_char == '_' {
+        if next_char.is_alphabetic() || next_char.is_numeric() || next_char == '_' {
             return rewrite_column_name_in_expr(
                 col_name,
                 table_ref_str,

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -221,11 +221,11 @@ fn rewrite_column_name_in_expr(
         &col_name[idx + table_ref_str.len()..]
     );
 
-    // Check if the rewritten name contains more occurrence of table_ref_str, and rewrite them as wel
+    // Check if the rewritten name contains more occurrence of table_ref_str, and rewrite them as well
     // This is done by providing the updated start_pos for search
     match rewrite_column_name_in_expr(&rewritten_name, table_ref_str, rewrite, idx + rewrite.len())
     {
-        Some(new_name) => Some(new_name), // more occurernces found
+        Some(new_name) => Some(new_name), // more occurrences found
         None => Some(rewritten_name),     // no more occurrences/changes
     }
 }


### PR DESCRIPTION
Fixes https://github.com/spiceai/spiceai/issues/1581

Improve expressions logic re-write to correctly handle cases where 

1. part of expression matches table name, for example

```sql
SELECT app_table_a FROM (SELECT a as app_table_a FROM app_table)
```

`app_table_a` contains `app_table` but it should not be rewritten.

Note: I've tried to see if there is something we can use to make this more robust (TableReference, relationship, etc), but found no difference when column belongs to one of registered tables or just other name/alias

2. expression contains multiple instances of the same table or multiple different tables