### PR TITLE
Remove table reference mutating during logical planning, converting query when executing

### DIFF
--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -630,13 +630,10 @@ impl VirtualExecutionPlan {
 
     fn rewritten_query(&self) -> Result<String> {
         // Find all table scans, recover the SQLTableSource, find the remote table name and replace the name of the TableScan table.
-        let dialect = self.executor.dialect();
-        let unparser = Unparser::new(dialect.as_ref());
         let mut known_rewrites = HashMap::new();
-        let plan = rewrite_table_scans(&self.plan, &mut known_rewrites)?;
-        let ast = unparser.plan_to_sql(&plan)?;
-        let query = format!("{ast}");
-        Ok(query)
+        let ast = Unparser::new(self.executor.dialect().as_ref())
+            .plan_to_sql(&rewrite_table_scans(&self.plan, &mut known_rewrites)?)?;
+        Ok(format!("{ast}"))
     }
 }
 

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -628,7 +628,7 @@ impl VirtualExecutionPlan {
         Arc::new(Schema::from(df_schema))
     }
 
-    fn rewritten_query(&self) -> Result<String> {
+    fn sql(&self) -> Result<String> {
         // Find all table scans, recover the SQLTableSource, find the remote table name and replace the name of the TableScan table.
         let mut known_rewrites = HashMap::new();
         let ast = Unparser::new(self.executor.dialect().as_ref())
@@ -648,7 +648,7 @@ impl DisplayAs for VirtualExecutionPlan {
             write!(f, " compute_context={ctx}")?;
         }
         write!(f, " sql={ast}")?;
-        if let Ok(query) = self.rewritten_query() {
+        if let Ok(query) = self.sql() {
             write!(f, " rewritten_sql={query}")?;
         };
 
@@ -681,8 +681,7 @@ impl ExecutionPlan for VirtualExecutionPlan {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        self.executor
-            .execute(self.rewritten_query()?.as_str(), self.schema())
+        self.executor.execute(self.sql()?.as_str(), self.schema())
     }
 
     fn properties(&self) -> &PlanProperties {

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -87,10 +87,6 @@ impl SQLFederationAnalyzerRule {
 
 impl AnalyzerRule for SQLFederationAnalyzerRule {
     fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
-        // Find all table scans, recover the SQLTableSource, find the remote table name and replace the name of the TableScan table.
-        let mut known_rewrites = HashMap::new();
-        let plan = rewrite_table_scans(&plan, &mut known_rewrites)?;
-
         let fed_plan = FederatedPlanNode::new(plan.clone(), Arc::clone(&self.planner));
         let ext_node = Extension {
             node: Arc::new(fed_plan),
@@ -631,6 +627,17 @@ impl VirtualExecutionPlan {
         let df_schema = self.plan.schema().as_ref();
         Arc::new(Schema::from(df_schema))
     }
+
+    fn rewritten_query(&self) -> Result<String> {
+        // Find all table scans, recover the SQLTableSource, find the remote table name and replace the name of the TableScan table.
+        let dialect = self.executor.dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let mut known_rewrites = HashMap::new();
+        let plan = rewrite_table_scans(&self.plan, &mut known_rewrites)?;
+        let ast = unparser.plan_to_sql(&plan)?;
+        let query = format!("{ast}");
+        Ok(query)
+    }
 }
 
 impl DisplayAs for VirtualExecutionPlan {
@@ -643,7 +650,12 @@ impl DisplayAs for VirtualExecutionPlan {
         if let Some(ctx) = self.executor.compute_context() {
             write!(f, " compute_context={ctx}")?;
         }
-        write!(f, " sql={ast}")
+        write!(f, " sql={ast}")?;
+        if let Ok(query) = self.rewritten_query() {
+            write!(f, " rewritten_sql={query}")?;
+        };
+
+        Ok(())
     }
 }
 
@@ -672,12 +684,8 @@ impl ExecutionPlan for VirtualExecutionPlan {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let dialect = self.executor.dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let ast = unparser.plan_to_sql(&self.plan)?;
-        let query = format!("{ast}");
-
-        self.executor.execute(query.as_str(), self.schema())
+        self.executor
+            .execute(self.rewritten_query()?.as_str(), self.schema())
     }
 
     fn properties(&self) -> &PlanProperties {


### PR DESCRIPTION
This fixes two things:
- a missing qualifier when wrap_projection, which will cause ambiguous selecting when join two tables as they contain same column name
- change the logic of how we handle the convention between df table to source table. Instead of mutating the plan during planning that could confuse df entire logic plan tree, this will create a query-only plan with all necessary rewrites when executing.

after this, inner join starts working
```
sql> explain  select * from fed inner join acc on acc.email = fed.email;
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                     |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Inner Join: fed.email = acc.email                                                                                                                                                                                                                                        |
|               |   Federated                                                                                                                                                                                                                                                              |
|               |  Projection: fed.email, fed.username, fed.items_bought                                                                                                                                                                                                                   |
|               |   TableScan: fed                                                                                                                                                                                                                                                         |
|               |   TableScan: acc projection=[email, username, items_bought]                                                                                                                                                                                                              |
| physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                                                                                                                                                                              |
|               |   HashJoinExec: mode=Partitioned, join_type=Inner, on=[(email@0, email@0)]                                                                                                                                                                                               |
|               |     CoalesceBatchesExec: target_batch_size=8192                                                                                                                                                                                                                          |
|               |       RepartitionExec: partitioning=Hash([email@0], 14), input_partitions=14                                                                                                                                                                                             |
|               |         SchemaCastScanExec                                                                                                                                                                                                                                               |
|               |           RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1                                                                                                                                                                                          |
|               |             VirtualExecutionPlan name=postgres compute_context=host=Tcp("localhost"),port=15432,db=postgres,user=postgres, sql=SELECT fed.email, fed.username, fed.items_bought FROM fed rewritten_sql=SELECT users.email, users.username, users.items_bought FROM users |
|               |     CoalesceBatchesExec: target_batch_size=8192                                                                                                                                                                                                                          |
|               |       RepartitionExec: partitioning=Hash([email@0], 14), input_partitions=14                                                                                                                                                                                             |
|               |         RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1                                                                                                                                                                                            |
|               |           SchemaCastScanExec                                                                                                                                                                                                                                             |
|               |             MemoryExec: partitions=1, partition_sizes=[1]                                                                                                                                                                                                                |
|               |                                                                                                                                                                                                                                                                          |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

Time: 0.013297833 seconds. 2 rows.
sql> select * from fed inner join acc on acc.email = fed.email;
+-------+----------+--------------+-------+----------+--------------+
| email | username | items_bought | email | username | items_bought |
+-------+----------+--------------+-------+----------+--------------+
| email | username | 1            | email | username | 1            |
+-------+----------+--------------+-------+----------+--------------+
```