### PR TITLE
Make the `FederatedPlanner` public for use in custom query planners

### DIFF
--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -121,7 +121,7 @@ impl Hash for FederatedPlanNode {
 }
 
 #[derive(Default)]
-struct FederatedPlanner {}
+pub struct FederatedPlanner {}
 
 impl FederatedPlanner {
     pub fn new() -> Self {


### PR DESCRIPTION
## 🗣 Description

Changes the visibility of `FederatedPlanner` to public to allow custom QueryPlanners to include it along with other extension planners.