### PR TITLE
Correctly handle unnest by FederationAnalyzerRule

### DIFF
--- a/datafusion-federation/src/analyzer.rs
+++ b/datafusion-federation/src/analyzer.rs
@@ -115,7 +115,12 @@ impl FederationAnalyzerRule {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let new_plan = plan.with_new_exprs(plan.expressions(), new_inputs)?;
+        let new_plan = match plan {
+            // Unnest returns columns to unnest as `expressions` but does not support passing them back to `with_new_exprs`.
+            // Instead, it uses data from its internal representation to create a new plan.
+            LogicalPlan::Unnest(_) => plan.with_new_exprs(vec![], new_inputs)?,
+            _ => plan.with_new_exprs(plan.expressions(), new_inputs)?,
+        };
 
         Ok((Some(new_plan), None))
     }


### PR DESCRIPTION
## 🗣 Description

Improve `FederationAnalyzerRule` to correctly handle Unnest LP.

Unnest returns columns to unnest as `expressions` but does not support passing them back to `with_new_exprs` - see `assert_no_expressions `. Instead, it uses data from its internal representation.

```rust
LogicalPlan::Unnest(Unnest {
    exec_columns: columns,
    options,
    ..
}) => {
    self.assert_no_expressions(expr)?;
    let input = self.only_input(inputs)?;
    // Update schema with unnested column type.
    let new_plan =
        unnest_with_options(input, columns.clone(), options.clone())?;
    Ok(new_plan)
}
```

