### PR TITLE
fix: rewrite shouldn't be performed on a column name same as the table name

### DIFF
--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -304,7 +304,7 @@ fn rewrite_column_name_in_expr(
     // Calculate the absolute index of the occurrence in string as the index above is relative to start_pos
     let idx = start_pos + idx;
 
-    // Table name same as column alias name
+    // Table name same as column name
     // Shouldn't rewrite in this case
     if idx == 0 && start_pos == 0 {
         return None;

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -1078,6 +1078,23 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_rewrite_same_column_table_name() -> Result<()> {
+        init_tracing();
+        let ctx = get_test_df_context();
+
+        let tests = vec![(
+            "SELECT app_table FROM (SELECT a app_table from app_table limit 100);",
+            r#"SELECT app_table FROM (SELECT remote_table.a AS app_table FROM remote_table LIMIT 100)"#,
+        )];
+
+        for test in tests {
+            test_sql(&ctx, test.0, test.1).await?;
+        }
+
+        Ok(())
+    }
+
     async fn test_sql(
         ctx: &SessionContext,
         sql_query: &str,

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -304,6 +304,12 @@ fn rewrite_column_name_in_expr(
     // Calculate the absolute index of the occurrence in string as the index above is relative to start_pos
     let idx = start_pos + idx;
 
+    // Table name same as column alias name
+    // Shouldn't rewrite in this case
+    if idx == 0 && start_pos == 0 {
+        return None;
+    }
+
     if idx > 0 {
         // Check if the previous character is alphabetic, numeric, underscore or period, in which case we
         // should not rewrite as it is a part of another name.


### PR DESCRIPTION
## 🗣 Description

When attempting to rewrite a query like `select call_center from (select cc_call_center_id Call_Center from call_center order by cc_call_center_id limit 100);`, where `call_center` table is rewritten to source `source_schema.call_center`, the rewrite mechanism would wrongly rewrite the **column** subquery alias `call_center` using **table** rewrite, making the `select call_center` a `select source_schema.call_center`, which is incorrect.

This PR fix the issue.

Also added a unit test, which would fail without the fix

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/4009

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
