### PR TITLE
fix: filter expressions within the tablescan should also be rewritten

### DIFF
--- a/sources/sql/src/rewrite/plan.rs
+++ b/sources/sql/src/rewrite/plan.rs
@@ -60,6 +60,20 @@ pub(crate) fn rewrite_table_scans(
                         .replace_qualifier(remote_table_name.clone());
                     new_table_scan.projected_schema = Arc::new(new_schema);
                     new_table_scan.table_name = remote_table_name.clone();
+
+                    // Rewrite the filter expression in table scan
+                    let mut new_filter_expressions = vec![];
+                    for expression in &table_scan.filters {
+                        let new_expr = rewrite_table_scans_in_expr(
+                            expression.clone(),
+                            known_rewrites,
+                            subquery_uses_partial_path,
+                            subquery_table_scans,
+                        )?;
+                        new_filter_expressions.push(new_expr);
+                    }
+
+                    new_table_scan.filters = new_filter_expressions;
                 }
                 None => {
                     // Not a SQLTableSource (is this possible?)


### PR DESCRIPTION
## 🗣 Description

When rewritting the expressions, the filter expressions within the table scan were ignored previously. This PR fixes the issue by rewritting Filter expressions within the tablescan.

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/4077

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
