### PR TITLE
feat: fix OuterReferenceColumns not being rewritten correctly (take 2)

### DIFF
--- a/sources/sql/src/rewrite/plan.rs
+++ b/sources/sql/src/rewrite/plan.rs
@@ -21,10 +21,53 @@ use datafusion_federation::{get_table_source, table_reference::MultiPartTableRef
 
 use crate::SQLTableSource;
 
+fn collect_known_rewrites(
+    plan: &LogicalPlan,
+    known_rewrites: &mut HashMap<TableReference, MultiPartTableReference>,
+) -> Result<()> {
+    if let LogicalPlan::TableScan(table_scan) = plan {
+        let original_table_name = table_scan.table_name.clone();
+
+        if let Some(federated_source) = get_table_source(&table_scan.source)? {
+            if let Some(sql_table_source) =
+                federated_source.as_any().downcast_ref::<SQLTableSource>()
+            {
+                let remote_table_name = sql_table_source.table_name();
+                known_rewrites.insert(original_table_name, remote_table_name.clone());
+            }
+        }
+    }
+
+    // Recursively collect from all inputs
+    for input in plan.inputs() {
+        collect_known_rewrites(input, known_rewrites)?;
+    }
+
+    Ok(())
+}
+
 /// Rewrite table scans to use the original federated table name.
 pub(crate) fn rewrite_table_scans(
     plan: &LogicalPlan,
     known_rewrites: &mut HashMap<TableReference, MultiPartTableReference>,
+    subquery_uses_partial_path: bool,
+    subquery_table_scans: &mut Option<HashSet<TableReference>>,
+) -> Result<LogicalPlan> {
+    // First pass: collect all known rewrites
+    collect_known_rewrites(plan, known_rewrites)?;
+
+    // Second pass: do the actual rewriting with complete known_rewrites
+    rewrite_plan_with_known_rewrites(
+        plan,
+        known_rewrites,
+        subquery_uses_partial_path,
+        subquery_table_scans,
+    )
+}
+
+fn rewrite_plan_with_known_rewrites(
+    plan: &LogicalPlan,
+    known_rewrites: &HashMap<TableReference, MultiPartTableReference>,
     subquery_uses_partial_path: bool,
     subquery_table_scans: &mut Option<HashSet<TableReference>>,
 ) -> Result<LogicalPlan> {
@@ -41,7 +84,6 @@ pub(crate) fn rewrite_table_scans(
             match federated_source.as_any().downcast_ref::<SQLTableSource>() {
                 Some(sql_table_source) => {
                     let remote_table_name = sql_table_source.table_name();
-                    known_rewrites.insert(original_table_name.clone(), remote_table_name.clone());
 
                     // If the remote table name is a MultiPartTableReference, we will not rewrite it here, but rewrite it after the final unparsing on the AST directly.
                     let MultiPartTableReference::TableReference(remote_table_name) =
@@ -91,7 +133,7 @@ pub(crate) fn rewrite_table_scans(
         .inputs()
         .into_iter()
         .map(|i| {
-            rewrite_table_scans(
+            rewrite_plan_with_known_rewrites(
                 i,
                 known_rewrites,
                 subquery_uses_partial_path,
@@ -172,7 +214,7 @@ pub(crate) fn rewrite_table_scans(
 fn rewrite_unnest_plan(
     unnest: &logical_expr::Unnest,
     mut rewritten_inputs: Vec<LogicalPlan>,
-    known_rewrites: &mut HashMap<TableReference, MultiPartTableReference>,
+    known_rewrites: &HashMap<TableReference, MultiPartTableReference>,
     subquery_uses_partial_path: bool,
     subquery_table_scans: &mut Option<HashSet<TableReference>>,
 ) -> Result<LogicalPlan> {
@@ -391,14 +433,14 @@ fn rewrite_column_name_in_expr(
 
 fn rewrite_table_scans_in_expr(
     expr: Expr,
-    known_rewrites: &mut HashMap<TableReference, MultiPartTableReference>,
+    known_rewrites: &HashMap<TableReference, MultiPartTableReference>,
     subquery_uses_partial_path: bool,
     subquery_table_scans: &mut Option<HashSet<TableReference>>,
 ) -> Result<Expr> {
     match expr {
         Expr::ScalarSubquery(subquery) => {
             let new_subquery = if subquery_table_scans.is_some() || !subquery_uses_partial_path {
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -406,7 +448,7 @@ fn rewrite_table_scans_in_expr(
                 )?
             } else {
                 let mut scans = Some(HashSet::new());
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -888,7 +930,7 @@ fn rewrite_table_scans_in_expr(
         }
         Expr::Exists(exists) => {
             let subquery_plan = if subquery_table_scans.is_some() || !subquery_uses_partial_path {
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &exists.subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -896,7 +938,7 @@ fn rewrite_table_scans_in_expr(
                 )?
             } else {
                 let mut scans = Some(HashSet::new());
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &exists.subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -930,7 +972,7 @@ fn rewrite_table_scans_in_expr(
                 subquery_table_scans,
             )?;
             let subquery_plan = if subquery_table_scans.is_some() || !subquery_uses_partial_path {
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &is.subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -938,7 +980,7 @@ fn rewrite_table_scans_in_expr(
                 )?
             } else {
                 let mut scans = Some(HashSet::new());
-                rewrite_table_scans(
+                rewrite_plan_with_known_rewrites(
                     &is.subquery.subquery,
                     known_rewrites,
                     subquery_uses_partial_path,
@@ -1373,6 +1415,22 @@ mod tests {
                 false,
             ),
         ];
+        for test in tests {
+            test_sql(&ctx, test.0, test.1, test.2).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rewrite_outer_ref_columns() -> Result<()> {
+        init_tracing();
+        let ctx = get_test_df_context();
+        let tests = vec![(
+            "SELECT foo.df_table.a FROM bar JOIN foo.df_table ON foo.df_table.a = (SELECT bar.a FROM bar WHERE bar.a > foo.df_table.a)",
+            r#"SELECT remote_table.a FROM remote_db.remote_schema.remote_table JOIN remote_table ON (remote_table.a = (SELECT a FROM remote_db.remote_schema.remote_table WHERE (remote_table.a > remote_table.a)))"#,
+            true,
+        )];
         for test in tests {
             test_sql(&ctx, test.0, test.1, test.2).await?;
         }


### PR DESCRIPTION
## 🗣 Description

Attempt number 2 at fixing the bug, original PR was #38. Attached is the context from that PR.

The missing piece was that I needed to add a pass to collect any subquery table scans from expressions, since they were being collecting during the original logic and I broke it when I only considered the table scans from the logical plan nodes.

## Original Description

An OuterReferenceColumn (aka correlated subquery) is a column in a subquery that references a column from the parent query.

Consider the following query:

```sql
SELECT employee_name,
       (SELECT AVG(salary)
        FROM salaries s2
        WHERE s2.department = e.department) as dept_avg_salary
FROM employees e;
```

In this query, `e.department` in the subquery refers to the department from the outer query's `employees` table. For each employee in the outer query, the subquery calculates the average salary for their department.
This is a correlated subquery because the inner query references the outer table e. The subquery runs once for each row in the outer query (logically, in practice this almost never happens since it would be so inefficient).

When federating a LogicalPlan to a remote database, we rewrite all table references from referencing their original name that they are registered in DataFusion as, into their remote name as they are registered in their remote database.

This PR fixes a bug in how that rewrite happened. Previously we would DFS search the LogicalPlan to find all of the TableScans, which allows us to build up a map of rewrites from the DataFusion table name to the remote table name. This usually works well, because a higher-level plan or expression can't reference a table that hasn't been scanned - except in the case of correlated subqueries. It is possible that we can come across an expression that has a correlated subquery which references a table that we haven't come across the TableScan for yet. When this happened, we were incorrectly skipping the rewrite - leading to an incorrect final query.

The solution is to first do a pass to find all of the TableScans to build up the map, and then do the rewrites once we have collected all of them.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
