### PR TITLE
Add remote_table_name to FederatedTableSource instead of downcasting to SQLTableSource

### DIFF
--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -13,7 +13,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
 };
 
-use crate::FederationProvider;
+use crate::{table_reference::MultiPartTableReference, FederationProvider};
 
 // FederatedTableSourceWrapper helps to recover the FederatedTableSource
 // from a TableScan. This wrapper may be avoidable.
@@ -150,6 +150,15 @@ impl TableProvider for FederatedTableProviderAdaptor {
 // to allow grouping of TableScans of the same FederationProvider.
 #[async_trait]
 pub trait FederatedTableSource: TableSource {
-    // Return the FederationProvider associated with this Table
+    /// Returns the remote table name for this table, if different from the
+    /// local table name registered in DataFusion.
+    ///
+    /// The remote table name is a `MultiPartTableReference` because some systems
+    /// allow arbitrarily nested table names (i.e. `catalog.namespace1.namespace2.table`).
+    fn remote_table_name(&self) -> Option<MultiPartTableReference> {
+        None
+    }
+
+    /// Return the FederationProvider associated with this Table
     fn federation_provider(&self) -> Arc<dyn FederationProvider>;
 }

--- a/datafusion-federation/src/table_reference.rs
+++ b/datafusion-federation/src/table_reference.rs
@@ -345,7 +345,7 @@ mod tests {
             Arc::from(r#"part"4"#),
         ];
         let multi = MultiPartTableReference::Multi(MultiTableReference {
-            parts: parts.into_iter().map(Arc::from).collect(),
+            parts: parts.into_iter().collect(),
         });
         assert_eq!(
             multi.to_quoted_string(),

--- a/sources/sql/src/rewrite/plan.rs
+++ b/sources/sql/src/rewrite/plan.rs
@@ -29,10 +29,7 @@ fn collect_known_rewrites_from_plan(
         let original_table_name = table_scan.table_name.clone();
 
         if let Some(federated_source) = get_table_source(&table_scan.source)? {
-            if let Some(sql_table_source) =
-                federated_source.as_any().downcast_ref::<SQLTableSource>()
-            {
-                let remote_table_name = sql_table_source.table_name();
+            if let Some(remote_table_name) = federated_source.remote_table_name() {
                 known_rewrites.insert(original_table_name, remote_table_name.clone());
             }
         }

--- a/sources/sql/src/schema.rs
+++ b/sources/sql/src/schema.rs
@@ -161,6 +161,10 @@ impl SQLTableSource {
 }
 
 impl FederatedTableSource for SQLTableSource {
+    fn remote_table_name(&self) -> Option<MultiPartTableReference> {
+        Some(self.table_name.clone())
+    }
+
     fn federation_provider(&self) -> Arc<dyn FederationProvider> {
         Arc::clone(&self.provider) as Arc<dyn FederationProvider>
     }


### PR DESCRIPTION
## 🗣 Description

Adds a new method  on the `FederatedTableSource`:

```rust
    /// Returns the remote table name for this table, if different from the
    /// local table name registered in DataFusion.
    ///
    /// The remote table name is a `MultiPartTableReference` because some systems
    /// allow arbitrarily nested table names (i.e. `catalog.namespace1.namespace2.table`).
    fn remote_table_name(&self) -> Option<MultiPartTableReference> {
        None
    }
```

This allows recovering the remote table name from the analyzer rules without having to depend on a concrete type (i.e. `SQLTableSource`).
