### PR TITLE
fix: join rewrite can handle the Equijoin clause

### DIFF
--- a/sources/sql/src/rewrite/plan.rs
+++ b/sources/sql/src/rewrite/plan.rs
@@ -318,7 +318,7 @@ fn rewrite_plan_with_known_rewrites(
         }
         LogicalPlan::Join(datafusion::logical_expr::Join { on, filter, .. }) => {
             let mut new_expressions = vec![];
-            if on.len() > 0 {
+            if !on.is_empty() {
                 for (left, right) in on {
                     let left = rewrite_table_scans_in_expr(
                         left.clone(),


### PR DESCRIPTION
## 🗣 Description

Correctly federate the `LogicalPlan::Join`. handle the on expression, which represent the Equijoin clause (e.g. ON a = b) in the Vec<(Expr, Expr)> format. When directly read from plan.exprs(), the Equijoin clause is readed as separate exprs Expr(Col(a)) Expr(Col(b)), instead of a Expr(Binary) of a = b, which causes error in https://github.com/apache/datafusion/blob/39063f6ccc403a6d0c8dd171318c5f201d516636/datafusion/expr/src/logical_plan/plan.rs#L924 and fail to federate the plan.

Note that the intersect / except sql query is parsed as logical plans with left semi / anti join with Equijoin clause represented in Join.on, whereas common join query have condition represented in Join.filter.

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/5948
- https://github.com/spiceai/spiceai/issues/5941

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
