### PR TITLE
Enable `FederationProvider` to dictate which `LogicalPlan`s it can federate. 

### DIFF
--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -31,6 +31,7 @@ arrow-json.workspace = true
 tokio.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing = "0.1.40"
+insta = { version = "1.42.0", features = ["filters"] }
 
 [[example]]
 name = "df-csv"

--- a/datafusion-federation/src/analyzer/mod.rs
+++ b/datafusion-federation/src/analyzer/mod.rs
@@ -251,7 +251,6 @@ impl FederationAnalyzerRule {
                 (_, None) => {
                     // Provider CAN'T federate this specific plan shape
                     // Fall through to try federating children instead
-                    sole_provider = ScanResult::Ambiguous;
                 }
             }
         }

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -64,7 +64,7 @@ pub trait FederationProvider: Send + Sync + std::fmt::Debug {
     //
     // Returns [`None`] if either the provider cannot federate any plan
     // (e.g. [`crate::analyzer::NopFederationProvider`]), or cannot federate
-    //  this [`LogicalPlan`].
+    //  this specific [`LogicalPlan`].
     fn analyzer(&self, plan: &LogicalPlan) -> Option<Arc<Analyzer>>;
 }
 

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 
 use datafusion::{
     execution::session_state::{SessionState, SessionStateBuilder},
+    logical_expr::LogicalPlan,
     optimizer::{
         analyzer::{
             resolve_grouping_function::ResolveGroupingFunction, type_coercion::TypeCoercion,
@@ -59,9 +60,12 @@ pub trait FederationProvider: Send + Sync + std::fmt::Debug {
     // will execute a query. For example: database instance & catalog.
     fn compute_context(&self) -> Option<String>;
 
-    // Returns an analyzer that can cut out part of the plan
-    // to federate it.
-    fn analyzer(&self) -> Option<Arc<Analyzer>>;
+    // Returns an analyzer that can cut out, and federate part of the [`LogicalPlan`].
+    //
+    // Returns [`None`] if either the provider cannot federate any plan
+    // (e.g. [`crate::analyzer::NopFederationProvider`]), or cannot federate
+    //  this [`LogicalPlan`].
+    fn analyzer(&self, plan: &LogicalPlan) -> Option<Arc<Analyzer>>;
 }
 
 impl fmt::Display for dyn FederationProvider {

--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -29,6 +29,14 @@ pub trait SQLExecutor: Sync + Send {
     /// The specific SQL dialect (currently supports 'sqlite', 'postgres', 'flight')
     fn dialect(&self) -> Arc<dyn Dialect>;
 
+    /// Returns if this executor can execute the query that would be produced from this logical plan.
+    ///
+    /// This is used to indicate to the federation logic that part of this plan cannot be federated,
+    /// i.e. if there are UDFs that only DataFusion can execute.
+    fn can_execute_plan(&self, _logical_plan: &LogicalPlan) -> bool {
+        true
+    }
+
     /// Returns the analyzer rule specific for this engine to modify the logical plan before execution
     fn logical_optimizer(&self) -> Option<LogicalOptimizer> {
         None

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -84,7 +84,6 @@ impl FederationProvider for SQLFederationProvider {
     }
 }
 
-/// This is actually where we figure out how much of the LP we can federate.
 #[derive(Debug)]
 struct SQLFederationAnalyzerRule {
     planner: Arc<SQLFederationPlanner>,

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -356,6 +356,7 @@ impl ExecutionPlan for VirtualExecutionPlan {
     }
 }
 
+#[allow(clippy::type_complexity)]
 #[cfg(test)]
 mod tests {
 

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -10,9 +10,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.98"
 duckdb = "1.1.3"
-
-# "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "7d4fa6d36b464a72afea88e7d3644e143c2535ad",
-datafusion-table-providers = { path = "../../datafusion-table-providers/core", features = [
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "374083cdccbb3f4e6ab7fa3ee6d1b6a87393f563", features = [
     "duckdb",
     "duckdb-federation",
 ] } # spiceai-50

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -10,10 +10,13 @@ publish = false
 [dependencies]
 anyhow = "1.0.98"
 duckdb = "1.1.3"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "374083cdccbb3f4e6ab7fa3ee6d1b6a87393f563", features = [
+
+# "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "7d4fa6d36b464a72afea88e7d3644e143c2535ad",
+datafusion-table-providers = { path = "../../datafusion-table-providers/core", features = [
     "duckdb",
     "duckdb-federation",
 ] } # spiceai-50
+
 datafusion = { workspace = true }
 tokio = { version = "1.35", features = ["rt", "rt-multi-thread", "macros"] }
 async-trait.workspace = true

--- a/integration-test/src/main.rs
+++ b/integration-test/src/main.rs
@@ -3,9 +3,6 @@ mod validation;
 
 use anyhow::{anyhow, Result};
 use bench::{Benchmark, Query};
-use datafusion::catalog::TableProvider;
-use datafusion_federation::sql::{SQLFederationProvider, SQLTableSource};
-use datafusion_federation::FederatedTableProviderAdaptor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -152,16 +149,13 @@ async fn register_federated_duckdb_tables(
     duckdb_table_factory: &DuckDBTableFactory,
 ) -> Result<()> {
     for table_name in table_names {
-        let tbl: Arc<dyn TableProvider> = Arc::new(
+        ctx.register_table(
+            &table_name,
             duckdb_table_factory
-                .table_provider_fed(TableReference::bare(table_name.as_str()))
+                .table_provider(TableReference::bare(table_name.as_str()))
                 .await
                 .map_err(|e| anyhow!("Failed to register duckdb table: {}", e))?,
-        );
-        tbl.as_any()
-            .downcast_ref::<FederatedTableProviderAdaptor>()
-            .expect("was not 'FederatedTableProviderAdaptor");
-        ctx.register_table(&table_name, tbl)?;
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
## 🗣 Description
- Update `FederationProvider::analyzer` trait so that a federation `Analyzer` (an `Analyzer` that creates federated sub-trees that can be unparsed into SQL and sent to the table provider) can be provided only when the underlying `TableProvider` can handle the provided `LogicalPlan`. 

```diff
- fn analyzer(&self) -> Option<Arc<Analyzer>>;
+ fn analyzer(&self, plan: &LogicalPlan) -> Option<Arc<Analyzer>>;
```
- This allows `FederationAnalyzerRule` to avoid federating sub-plans that would fail in the federated source (e.g. a `LogicalPlan` with DataFusion-specific UDFs).