### PR TITLE
Improve error message and add debug logging for cast failures

### DIFF
--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -26,11 +26,11 @@ async-trait.workspace = true
 datafusion.workspace = true
 async-stream.workspace = true
 arrow-json.workspace = true
+tracing = "0.1"
 
 [dev-dependencies]
 tokio.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing = "0.1.40"
 insta = { version = "1.42.0", features = ["filters"] }
 
 [[example]]

--- a/datafusion-federation/src/schema_cast/lists_cast.rs
+++ b/datafusion-federation/src/schema_cast/lists_cast.rs
@@ -30,7 +30,7 @@ macro_rules! cast_string_to_list_array {
                 None => list_builder.append_null(),
                 Some(string_value) => {
                     decoder.decode(string_value.as_bytes()).map_err(|e| {
-                        ArrowError::CastError(format!("Failed to decode value: {e}"))
+                        ArrowError::CastError(format!("Failed to decode value {string_value}: {e}"))
                     })?;
 
                     if let Some(b) = decoder.flush().map_err(|e| {


### PR DESCRIPTION
Improves the error messaged returned when casting a record batch into an expected schema fails. Also adds debug/trace logging for more details on which specifically has failed.