### PR TITLE
fix: federation analyzer skips child nodes on Unable; VirtualExecutionPlan drops parent filters

### DIFF
--- a/datafusion-federation/src/analyzer/mod.rs
+++ b/datafusion-federation/src/analyzer/mod.rs
@@ -264,7 +264,7 @@ impl FederationAnalyzerRule {
                 provider.analyzer(plan)
             };
             match (is_root, provider_analyzer) {
-                (false, Some(_)) => {
+                (false, Some(FederationAnalyzerForLogicalPlan::With(_))) => {
                     // The largest sub-plan is higher up.
                     return Ok((None, ScanResult::Distinct(provider)));
                 }

--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -14,6 +14,25 @@ use super::ast_analyzer::AstAnalyzer;
 
 pub type SQLExecutorRef = Arc<dyn SQLExecutor>;
 
+/// Indicates how a physical filter expression is handled when pushed down to a
+/// [`SQLExecutor`] via [`SQLExecutor::supports_filters_pushdown`].
+///
+/// Mirrors the semantics of
+/// [`TableProviderFilterPushDown`](datafusion::logical_expr::TableProviderFilterPushDown).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SQLFilterPushDown {
+    /// The executor cannot apply this filter. The parent `FilterExec` is kept in the
+    /// plan and evaluates the filter locally.
+    Unsupported,
+    /// The executor will apply this filter exactly inside [`SQLExecutor::execute`].
+    /// The parent `FilterExec` is removed from the plan.
+    Exact,
+    /// The executor will apply this filter as a hint (e.g. for early pruning in the
+    /// generated SQL), but may not apply it precisely. The parent `FilterExec` is kept
+    /// in the plan to guarantee correctness.
+    Inexact,
+}
+
 pub type LogicalOptimizer = Box<dyn FnMut(LogicalPlan) -> Result<LogicalPlan>>;
 pub type SqlQueryRewriter = Box<dyn FnMut(String) -> Result<String>>;
 
@@ -52,25 +71,30 @@ pub trait SQLExecutor: Sync + Send {
         None
     }
 
-    /// Returns whether this executor will apply `filter` when it is passed to [`Self::execute`].
+    /// Returns how each of the provided physical filter expressions is handled when pushed
+    /// down to this executor. Called once with all candidate filters; returns one
+    /// [`SQLFilterPushDown`] per filter.
     ///
-    /// [`VirtualExecutionPlan`](super::VirtualExecutionPlan) calls this for each physical filter
-    /// expression that a parent [`FilterExec`](datafusion::physical_plan::filter::FilterExec) wants
-    /// to push down. Returning `true` allows the `FilterExec` to be removed from the plan
-    /// (the executor is then responsible for applying the filter inside [`Self::execute`]).
-    /// Returning `false` keeps the `FilterExec` in place for local evaluation.
+    /// - [`Unsupported`](SQLFilterPushDown::Unsupported): filter is not passed to
+    ///   [`Self::execute`]; the parent `FilterExec` stays in the plan for local evaluation.
+    /// - [`Exact`](SQLFilterPushDown::Exact): filter is passed to [`Self::execute`] and
+    ///   applied precisely; the parent `FilterExec` is removed.
+    /// - [`Inexact`](SQLFilterPushDown::Inexact): filter is passed to [`Self::execute`] as
+    ///   a hint (e.g. for early pruning in the generated SQL) but may not be applied
+    ///   exactly; the parent `FilterExec` is kept for correctness.
     ///
-    /// The default is `false` — filters are not applied. Override to opt in, e.g. for
-    /// runtime-only expressions like `DynamicFilterPhysicalExpr` that can be injected into
-    /// the SQL at execution time.
-    fn can_handle_filter(&self, _filter: &dyn PhysicalExpr) -> bool {
-        false
+    /// The default returns [`Unsupported`](SQLFilterPushDown::Unsupported) for every filter.
+    /// Override to opt in, e.g. for runtime-only expressions like `DynamicFilterPhysicalExpr`
+    /// that can be injected into the SQL at execution time.
+    fn supports_filters_pushdown(&self, filters: &[&dyn PhysicalExpr]) -> Vec<SQLFilterPushDown> {
+        vec![SQLFilterPushDown::Unsupported; filters.len()]
     }
 
     /// Execute a SQL query.
     ///
-    /// `filters` contain physical expressions for which [`Self::can_handle_filter`] returned
-    /// `true`. Their concrete values may only be available at execution time (e.g.
+    /// `filters` contain physical expressions for which [`Self::supports_filters_pushdown`]
+    /// returned [`Exact`](SQLFilterPushDown::Exact) or [`Inexact`](SQLFilterPushDown::Inexact).
+    /// Their concrete values may only be available at execution time (e.g.
     /// `DynamicFilterPhysicalExpr`), so they must be incorporated into the SQL query when the
     /// stream is polled.
     fn execute(

--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -52,12 +52,27 @@ pub trait SQLExecutor: Sync + Send {
         None
     }
 
+    /// Returns whether this executor will apply `filter` when it is passed to [`Self::execute`].
+    ///
+    /// [`VirtualExecutionPlan`](super::VirtualExecutionPlan) calls this for each physical filter
+    /// expression that a parent [`FilterExec`](datafusion::physical_plan::filter::FilterExec) wants
+    /// to push down. Returning `true` allows the `FilterExec` to be removed from the plan
+    /// (the executor is then responsible for applying the filter inside [`Self::execute`]).
+    /// Returning `false` keeps the `FilterExec` in place for local evaluation.
+    ///
+    /// The default is `false` — filters are not applied. Override to opt in, e.g. for
+    /// runtime-only expressions like `DynamicFilterPhysicalExpr` that can be injected into
+    /// the SQL at execution time.
+    fn can_handle_filter(&self, _filter: &dyn PhysicalExpr) -> bool {
+        false
+    }
+
     /// Execute a SQL query.
     ///
-    /// `filters` contain physical expressions generated at runtime, like
-    /// `DynamicFilterPhysicalExpr`. Since the concrete expression values only become available when
-    /// the `SendableRecordBatchStream` is executed, they must be manually added to the SQL query,
-    /// if necessary. However, they can be safely ignored.
+    /// `filters` contain physical expressions for which [`Self::can_handle_filter`] returned
+    /// `true`. Their concrete values may only be available at execution time (e.g.
+    /// `DynamicFilterPhysicalExpr`), so they must be incorporated into the SQL query when the
+    /// stream is polled.
     fn execute(
         &self,
         query: &str,

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -431,26 +431,14 @@ impl ExecutionPlan for VirtualExecutionPlan {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        let parent_filters: Vec<_> = child_pushdown_result
-            .parent_filters
-            .into_iter()
-            .map(|f| f.filter)
-            .collect();
-
-        if parent_filters.is_empty() {
-            return Ok(FilterPushdownPropagation {
-                filters: vec![],
-                updated_node: None,
-            });
-        }
-
-        let filters_pushed_down = vec![PushedDown::Yes; parent_filters.len()];
-        let mut node = self.clone();
-        node.filters = parent_filters;
-
+        // Do not accept static filter pushdown — the SQL already incorporates any
+        // filters that were part of the federation plan, and the SQLExecutor may
+        // not apply unrecognised expressions passed at execution time. Returning
+        // PushedDown::No keeps the parent FilterExec in place, guaranteeing that
+        // filters which were not absorbed into the SQL are still evaluated locally.
         Ok(FilterPushdownPropagation {
-            filters: filters_pushed_down,
-            updated_node: Some(Arc::new(node)),
+            filters: vec![PushedDown::No; child_pushdown_result.parent_filters.len()],
+            updated_node: None,
         })
     }
 }
@@ -1392,6 +1380,132 @@ mod tests {
                  ORDER BY numwait DESC, s_name",
             )
             .await
+        );
+    }
+
+    /// When `can_execute_plan` returns `false` for a `Filter → TableScan` plan at a
+    /// non-root level, the federation analyzer must still federate the `TableScan`
+    /// child and leave the `Filter` above it for local execution.
+    ///
+    /// Before the fix the `(false, Some(_))` match arm caught `Some(Unable)` and
+    /// returned early without trying children, so nothing got federated at all.
+    #[tokio::test]
+    async fn can_execute_plan_non_root_unable_federates_child_table_scan(
+    ) -> Result<(), DataFusionError> {
+        // Block federation of any plan node that is a Filter — simulates a
+        // denied UDF in the WHERE clause.
+        let executor = TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: Some(Arc::new(|plan| matches!(plan, LogicalPlan::Filter(_)))),
+        };
+
+        let table = get_test_table_provider("t".into(), executor);
+        let ctx = SessionContext::new_with_state(crate::default_session_state());
+        ctx.register_table("t", table).unwrap();
+
+        let df = ctx.sql("SELECT * FROM t WHERE a > 5").await?;
+        let physical_plan = df.create_physical_plan().await?;
+
+        let mut has_filter_exec = false;
+        let mut federation_sqls: Vec<String> = Vec::new();
+
+        physical_plan.apply(|node| {
+            if node.name() == "FilterExec" {
+                has_filter_exec = true;
+            }
+            if node.name() == "sql_federation_exec" {
+                let vp = node
+                    .as_any()
+                    .downcast_ref::<VirtualExecutionPlan>()
+                    .unwrap();
+                federation_sqls.push(vp.final_sql()?);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        assert!(
+            has_filter_exec,
+            "FilterExec must be present for the denied filter"
+        );
+        assert!(
+            !federation_sqls.is_empty(),
+            "VirtualExecutionPlan must be present — TableScan should still be federated"
+        );
+        for sql in &federation_sqls {
+            assert!(
+                !sql.to_lowercase().contains("where"),
+                "Federated SQL must not contain the denied filter predicate; got: {sql}"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// `VirtualExecutionPlan::handle_child_pushdown_result` must return
+    /// `PushedDown::No` for every filter so that `FilterExec` is never silently
+    /// removed while the executor ignores the passed expressions.
+    #[test]
+    fn virtual_execution_plan_declines_filter_pushdown() {
+        use datafusion::arrow::datatypes::DataType;
+        use datafusion::common::ScalarValue;
+        use datafusion::config::ConfigOptions;
+        use datafusion::physical_expr::expressions::Literal;
+        use datafusion::physical_plan::filter_pushdown::{
+            ChildFilterPushdownResult, ChildPushdownResult, FilterPushdownPhase,
+        };
+
+        let executor = TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: None,
+        };
+        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+            datafusion::arrow::datatypes::Field::new("a", DataType::Int64, false),
+        ]));
+        let plan = datafusion::logical_expr::LogicalPlan::EmptyRelation(
+            datafusion::logical_expr::EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(
+                    datafusion::common::DFSchema::try_from((*schema).clone()).unwrap(),
+                ),
+            },
+        );
+        let vp =
+            VirtualExecutionPlan::new(plan, Arc::new(executor), Statistics::new_unknown(&schema));
+
+        // Build a ChildPushdownResult with two mock parent filters.
+        let dummy_expr: Arc<dyn PhysicalExpr> =
+            Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
+        let parent_filters = vec![
+            ChildFilterPushdownResult {
+                filter: Arc::clone(&dummy_expr),
+                child_results: vec![PushedDown::Yes],
+            },
+            ChildFilterPushdownResult {
+                filter: Arc::clone(&dummy_expr),
+                child_results: vec![PushedDown::Yes],
+            },
+        ];
+        let child_result = ChildPushdownResult {
+            parent_filters,
+            self_filters: vec![],
+        };
+
+        let result = vp
+            .handle_child_pushdown_result(
+                FilterPushdownPhase::Post,
+                child_result,
+                &ConfigOptions::default(),
+            )
+            .unwrap();
+
+        assert!(
+            result.updated_node.is_none(),
+            "VirtualExecutionPlan must not update itself when declining filters"
+        );
+        assert!(
+            result.filters.iter().all(|f| matches!(f, PushedDown::No)),
+            "Every filter must be PushedDown::No; got: {:?}",
+            result.filters
         );
     }
 }

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -431,14 +431,48 @@ impl ExecutionPlan for VirtualExecutionPlan {
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
     ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        // Do not accept static filter pushdown — the SQL already incorporates any
-        // filters that were part of the federation plan, and the SQLExecutor may
-        // not apply unrecognised expressions passed at execution time. Returning
-        // PushedDown::No keeps the parent FilterExec in place, guaranteeing that
-        // filters which were not absorbed into the SQL are still evaluated locally.
+        // Ask the executor whether it will apply each filter inside execute().
+        // Filters the executor claims to handle are accepted (PushedDown::Yes), allowing
+        // the parent FilterExec to be removed — the executor is then responsible for
+        // applying them (e.g. by injecting them into the SQL at execution time).
+        // Filters the executor does not handle are declined (PushedDown::No), keeping
+        // the FilterExec in place for local evaluation.
+        //
+        // Note: filters that were part of the federation plan are already baked into
+        // final_sql() and never appear here — this path only sees filters that were
+        // NOT absorbed during logical federation planning.
+        let pushdown_results: Vec<PushedDown> = child_pushdown_result
+            .parent_filters
+            .iter()
+            .map(|f| {
+                if self.executor.can_handle_filter(f.filter.as_ref()) {
+                    PushedDown::Yes
+                } else {
+                    PushedDown::No
+                }
+            })
+            .collect();
+
+        let accepted: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
+            .parent_filters
+            .iter()
+            .zip(&pushdown_results)
+            .filter(|(_, pd)| matches!(pd, PushedDown::Yes))
+            .map(|(f, _)| Arc::clone(&f.filter))
+            .collect();
+
+        if accepted.is_empty() {
+            return Ok(FilterPushdownPropagation {
+                filters: pushdown_results,
+                updated_node: None,
+            });
+        }
+
+        let mut node = self.clone();
+        node.filters = accepted;
         Ok(FilterPushdownPropagation {
-            filters: vec![PushedDown::No; child_pushdown_result.parent_filters.len()],
-            updated_node: None,
+            filters: pushdown_results,
+            updated_node: Some(Arc::new(node)),
         })
     }
 }
@@ -1441,9 +1475,10 @@ mod tests {
         Ok(())
     }
 
-    /// `VirtualExecutionPlan::handle_child_pushdown_result` must return
-    /// `PushedDown::No` for every filter so that `FilterExec` is never silently
-    /// removed while the executor ignores the passed expressions.
+    /// `VirtualExecutionPlan::handle_child_pushdown_result` must consult
+    /// `SQLExecutor::can_handle_filter` for each filter. When the executor returns
+    /// `false` (the default), the filter must be declined so that `FilterExec`
+    /// stays in place for local evaluation.
     #[test]
     fn virtual_execution_plan_declines_filter_pushdown() {
         use datafusion::arrow::datatypes::DataType;

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -35,7 +35,9 @@ use datafusion::{
 use optimizer::{OptimizeProjectionsFederation, PushDownFilterFederation};
 
 pub use ast_analyzer::{AstAnalyzer, AstAnalyzerRule};
-pub use executor::{LogicalOptimizer, SQLExecutor, SQLExecutorRef, SqlQueryRewriter};
+pub use executor::{
+    LogicalOptimizer, SQLExecutor, SQLExecutorRef, SQLFilterPushDown, SqlQueryRewriter,
+};
 pub use schema::{MultiSchemaProvider, SQLSchemaProvider};
 pub use table::{RemoteTable, SQLTable, SQLTableSource};
 pub use table_reference::{MultiPartTableReference, RemoteTableRef};
@@ -441,23 +443,29 @@ impl ExecutionPlan for VirtualExecutionPlan {
         // Note: filters that were part of the federation plan are already baked into
         // final_sql() and never appear here — this path only sees filters that were
         // NOT absorbed during logical federation planning.
-        let pushdown_results: Vec<PushedDown> = child_pushdown_result
+        let filter_refs: Vec<&dyn PhysicalExpr> = child_pushdown_result
             .parent_filters
             .iter()
-            .map(|f| {
-                if self.executor.can_handle_filter(f.filter.as_ref()) {
-                    PushedDown::Yes
-                } else {
-                    PushedDown::No
-                }
+            .map(|f| f.filter.as_ref())
+            .collect();
+        let executor_support = self.executor.supports_filters_pushdown(&filter_refs);
+
+        // Exact   → pass to execute(), remove FilterExec (PushedDown::Yes)
+        // Inexact → pass to execute() as a hint, keep FilterExec (PushedDown::No)
+        // Unsupported → do not pass, keep FilterExec (PushedDown::No)
+        let pushdown_results: Vec<PushedDown> = executor_support
+            .iter()
+            .map(|s| match s {
+                SQLFilterPushDown::Exact => PushedDown::Yes,
+                SQLFilterPushDown::Inexact | SQLFilterPushDown::Unsupported => PushedDown::No,
             })
             .collect();
 
         let accepted: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
             .parent_filters
             .iter()
-            .zip(&pushdown_results)
-            .filter(|(_, pd)| matches!(pd, PushedDown::Yes))
+            .zip(&executor_support)
+            .filter(|(_, s)| matches!(s, SQLFilterPushDown::Exact | SQLFilterPushDown::Inexact))
             .map(|(f, _)| Arc::clone(&f.filter))
             .collect();
 
@@ -1475,27 +1483,11 @@ mod tests {
         Ok(())
     }
 
-    /// `VirtualExecutionPlan::handle_child_pushdown_result` must consult
-    /// `SQLExecutor::can_handle_filter` for each filter. When the executor returns
-    /// `false` (the default), the filter must be declined so that `FilterExec`
-    /// stays in place for local evaluation.
-    #[test]
-    fn virtual_execution_plan_declines_filter_pushdown() {
-        use datafusion::arrow::datatypes::DataType;
-        use datafusion::common::ScalarValue;
-        use datafusion::config::ConfigOptions;
-        use datafusion::physical_expr::expressions::Literal;
-        use datafusion::physical_plan::filter_pushdown::{
-            ChildFilterPushdownResult, ChildPushdownResult, FilterPushdownPhase,
-        };
+    // ── helpers shared by the filter-pushdown tests ──────────────────────────
 
-        let executor = TestExecutor {
-            compute_context: "ctx".into(),
-            cannot_federate: None,
-        };
-        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
-            datafusion::arrow::datatypes::Field::new("a", DataType::Int64, false),
-        ]));
+    fn make_vp_with_executor(executor: TestExecutor) -> VirtualExecutionPlan {
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
         let plan = datafusion::logical_expr::LogicalPlan::EmptyRelation(
             datafusion::logical_expr::EmptyRelation {
                 produce_one_row: false,
@@ -1504,43 +1496,210 @@ mod tests {
                 ),
             },
         );
-        let vp =
-            VirtualExecutionPlan::new(plan, Arc::new(executor), Statistics::new_unknown(&schema));
+        VirtualExecutionPlan::new(plan, Arc::new(executor), Statistics::new_unknown(&schema))
+    }
 
-        // Build a ChildPushdownResult with two mock parent filters.
-        let dummy_expr: Arc<dyn PhysicalExpr> =
-            Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
-        let parent_filters = vec![
-            ChildFilterPushdownResult {
-                filter: Arc::clone(&dummy_expr),
+    fn make_child_result(n: usize) -> ChildPushdownResult {
+        use datafusion::common::ScalarValue;
+        use datafusion::physical_expr::expressions::Literal;
+        use datafusion::physical_plan::filter_pushdown::ChildFilterPushdownResult;
+
+        let dummy: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Boolean(Some(true))));
+        let parent_filters = (0..n)
+            .map(|_| ChildFilterPushdownResult {
+                filter: Arc::clone(&dummy),
                 child_results: vec![PushedDown::Yes],
-            },
-            ChildFilterPushdownResult {
-                filter: Arc::clone(&dummy_expr),
-                child_results: vec![PushedDown::Yes],
-            },
-        ];
-        let child_result = ChildPushdownResult {
+            })
+            .collect();
+        ChildPushdownResult {
             parent_filters,
             self_filters: vec![],
-        };
+        }
+    }
 
-        let result = vp
-            .handle_child_pushdown_result(
-                FilterPushdownPhase::Post,
-                child_result,
-                &ConfigOptions::default(),
-            )
-            .unwrap();
+    fn run_pushdown(
+        vp: &VirtualExecutionPlan,
+        n: usize,
+    ) -> FilterPushdownPropagation<Arc<dyn ExecutionPlan>> {
+        use datafusion::config::ConfigOptions;
+        use datafusion::physical_plan::filter_pushdown::FilterPushdownPhase;
+        vp.handle_child_pushdown_result(
+            FilterPushdownPhase::Post,
+            make_child_result(n),
+            &ConfigOptions::default(),
+        )
+        .unwrap()
+    }
+
+    // ── per-variant tests ─────────────────────────────────────────────────────
+
+    /// Default executor: all filters unsupported → PushedDown::No, no node update.
+    #[test]
+    fn virtual_execution_plan_declines_filter_pushdown() {
+        let vp = make_vp_with_executor(TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: None,
+        });
+        let result = run_pushdown(&vp, 2);
 
         assert!(
             result.updated_node.is_none(),
-            "VirtualExecutionPlan must not update itself when declining filters"
+            "Unsupported: node must not be updated"
         );
         assert!(
             result.filters.iter().all(|f| matches!(f, PushedDown::No)),
-            "Every filter must be PushedDown::No; got: {:?}",
+            "Unsupported: every filter must be PushedDown::No; got: {:?}",
             result.filters
+        );
+    }
+
+    /// Executor that accepts all filters as Exact: FilterExec is removed (PushedDown::Yes)
+    /// and filters are stored on the updated node for injection into execute().
+    #[test]
+    fn virtual_execution_plan_exact_filter_pushdown() {
+        #[derive(Clone, Debug)]
+        struct ExactExecutor(TestExecutor);
+
+        #[async_trait]
+        impl SQLExecutor for ExactExecutor {
+            fn name(&self) -> &str {
+                self.0.name()
+            }
+            fn compute_context(&self) -> Option<String> {
+                self.0.compute_context()
+            }
+            fn dialect(&self) -> Arc<dyn Dialect> {
+                self.0.dialect()
+            }
+            fn supports_filters_pushdown(
+                &self,
+                filters: &[&dyn PhysicalExpr],
+            ) -> Vec<SQLFilterPushDown> {
+                vec![SQLFilterPushDown::Exact; filters.len()]
+            }
+            fn execute(
+                &self,
+                q: &str,
+                s: SchemaRef,
+                f: &[Arc<dyn PhysicalExpr>],
+            ) -> Result<SendableRecordBatchStream> {
+                self.0.execute(q, s, f)
+            }
+            async fn table_names(&self) -> Result<Vec<String>> {
+                self.0.table_names().await
+            }
+            async fn get_table_schema(&self, t: &str) -> Result<SchemaRef> {
+                self.0.get_table_schema(t).await
+            }
+        }
+
+        let vp = make_vp_with_executor(TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: None,
+        });
+        // Re-wrap with ExactExecutor
+        let vp2 = VirtualExecutionPlan {
+            executor: Arc::new(ExactExecutor(TestExecutor {
+                compute_context: "ctx".into(),
+                cannot_federate: None,
+            })),
+            ..vp
+        };
+        let result = run_pushdown(&vp2, 2);
+
+        assert!(
+            result.updated_node.is_some(),
+            "Exact: node must be updated with accepted filters"
+        );
+        assert!(
+            result.filters.iter().all(|f| matches!(f, PushedDown::Yes)),
+            "Exact: every filter must be PushedDown::Yes (FilterExec removed); got: {:?}",
+            result.filters
+        );
+        // Filters must be stored on the updated node for execute().
+        let updated = result.updated_node.unwrap();
+        let updated_vp = updated
+            .as_any()
+            .downcast_ref::<VirtualExecutionPlan>()
+            .unwrap();
+        assert_eq!(
+            updated_vp.filters.len(),
+            2,
+            "Exact: both filters must be stored on the node"
+        );
+    }
+
+    /// Executor that accepts all filters as Inexact: FilterExec is kept (PushedDown::No)
+    /// but filters are stored on the updated node so execute() can use them as hints.
+    #[test]
+    fn virtual_execution_plan_inexact_filter_pushdown() {
+        #[derive(Clone, Debug)]
+        struct InexactExecutor(TestExecutor);
+
+        #[async_trait]
+        impl SQLExecutor for InexactExecutor {
+            fn name(&self) -> &str {
+                self.0.name()
+            }
+            fn compute_context(&self) -> Option<String> {
+                self.0.compute_context()
+            }
+            fn dialect(&self) -> Arc<dyn Dialect> {
+                self.0.dialect()
+            }
+            fn supports_filters_pushdown(
+                &self,
+                filters: &[&dyn PhysicalExpr],
+            ) -> Vec<SQLFilterPushDown> {
+                vec![SQLFilterPushDown::Inexact; filters.len()]
+            }
+            fn execute(
+                &self,
+                q: &str,
+                s: SchemaRef,
+                f: &[Arc<dyn PhysicalExpr>],
+            ) -> Result<SendableRecordBatchStream> {
+                self.0.execute(q, s, f)
+            }
+            async fn table_names(&self) -> Result<Vec<String>> {
+                self.0.table_names().await
+            }
+            async fn get_table_schema(&self, t: &str) -> Result<SchemaRef> {
+                self.0.get_table_schema(t).await
+            }
+        }
+
+        let vp = make_vp_with_executor(TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: None,
+        });
+        let vp2 = VirtualExecutionPlan {
+            executor: Arc::new(InexactExecutor(TestExecutor {
+                compute_context: "ctx".into(),
+                cannot_federate: None,
+            })),
+            ..vp
+        };
+        let result = run_pushdown(&vp2, 2);
+
+        assert!(
+            result.updated_node.is_some(),
+            "Inexact: node must be updated so filters reach execute()"
+        );
+        assert!(
+            result.filters.iter().all(|f| matches!(f, PushedDown::No)),
+            "Inexact: FilterExec must stay (PushedDown::No); got: {:?}",
+            result.filters
+        );
+        let updated = result.updated_node.unwrap();
+        let updated_vp = updated
+            .as_any()
+            .downcast_ref::<VirtualExecutionPlan>()
+            .unwrap();
+        assert_eq!(
+            updated_vp.filters.len(),
+            2,
+            "Inexact: both filters must be stored on the node for execute()"
         );
     }
 }

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.98"
-duckdb = "1.1.3"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "eeaa4085e7238736abe8166f2afb795e6d99c08c", features = [
+duckdb = "1.10503"
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "9955a7b961602b9ad54a31265245628e71173edd", features = [
     "duckdb",
     "duckdb-federation",
-] } # spiceai-52
+] } # sgrebnov/spiceai-53
 
 datafusion = { workspace = true }
 tokio = { version = "1.35", features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
**1. Analyzer: allow children federation when `can_execute_plan` returns false at non-root level** — The `(false, Some(_))` match arm was catching `Some(Unable)` before it could fall through to try federating child nodes. Changed to `(false, Some(With(_)))` so that when a plan node (e.g. a `Filter` containing a denied UDF) can't be federated, its children (e.g. the `TableScan`) are still considered for federation.

**2. `VirtualExecutionPlan`: delegate filter pushdown acceptance to `SQLExecutor::can_handle_filter`** — `handle_child_pushdown_result` was unconditionally accepting all parent filters as `PushedDown::Yes`, causing `FilterExec` to be removed from the plan. Since `SQLExecutor::execute` implementations are permitted to ignore the filters argument, this silently dropped filters that were not part of the federation SQL, producing incorrect query results. The fix adds `SQLExecutor::can_handle_filter` (default: `false`) and makes `handle_child_pushdown_result` consult it per filter: only filters the executor explicitly claims to handle are accepted; the rest return `PushedDown::No`, keeping `FilterExec`in place for local evaluation