### PR TITLE
fix: inline projection aliases inside ORDER BY CASE (Postgres SQLSTATE 42703)

### DIFF
--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -32,6 +32,16 @@ tracing = "0.1"
 tokio.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 insta = { version = "1.42.0", features = ["filters"] }
+anyhow = "1"
+tokio-postgres = "0.7"
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["postgres"] }
+async-trait.workspace = true
+futures.workspace = true
+
+[[test]]
+name = "postgres_federation"
+required-features = ["sql"]
 
 [[example]]
 name = "df-csv"

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -3,6 +3,7 @@ pub mod ast_analyzer;
 mod executor;
 pub mod optimizer;
 mod schema;
+mod sort_alias_inliner;
 mod table;
 mod table_reference;
 
@@ -220,6 +221,14 @@ impl VirtualExecutionPlan {
         let plan = RewriteTableScanAnalyzer::rewrite(plan, &known_rewrites)?;
         let (logical_optimizers, ast_analyzers, sql_query_rewriters) = gather_analyzers(&plan)?;
         let plan = apply_logical_optimizers(plan, logical_optimizers)?;
+        // Re-inline projection alias expressions that appear inside compound ORDER BY
+        // expressions.  PostgreSQL (and the SQL standard) allow a bare output-column alias
+        // as a top-level sort key but NOT inside a larger expression such as a CASE.
+        // DataFusion's unparser only re-inlines ScalarFunction projection exprs, so any
+        // other shape (e.g. BinaryExpr `grouping(a)+grouping(b)`) leaks as a bare alias
+        // column inside the generated SQL, causing Postgres error 42703.
+        // See: datafusion-federation/src/sql/sort_alias_inliner.rs for the full writeup.
+        let plan = sort_alias_inliner::inline_sort_projection_aliases(plan)?;
         let ast = self.plan_to_statement(&plan)?;
         let ast = self.rewrite_with_executor_ast_analyzer(ast)?;
         let mut ast = apply_ast_analyzers(ast, ast_analyzers)?;
@@ -1692,6 +1701,101 @@ mod tests {
             updated_vp.filters.len(),
             2,
             "Inexact: both filters must be stored on the node for execute()"
+        );
+    }
+
+    // ── sort alias inliner regression ────────────────────────────────────────
+
+    /// Regression: an alias referenced inside a CASE expression in ORDER BY must
+    /// be inlined before unparsing.
+    ///
+    /// PostgreSQL allows a bare output-column alias as a top-level sort key
+    /// (`ORDER BY "s"`) but rejects the same alias inside a compound expression
+    /// (`ORDER BY CASE WHEN "s" = 0 THEN … END`), returning SQLSTATE 42703.
+    ///
+    /// `VirtualExecutionPlan::final_sql` must call `inline_sort_projection_aliases`
+    /// so the alias is replaced by the underlying expression before the SQL is
+    /// emitted.  Without that call this test fails because the generated SQL
+    /// contains `CASE WHEN "s" = 0`.
+    #[test]
+    fn final_sql_does_not_leak_alias_inside_order_by_case() {
+        use datafusion::common::DFSchema;
+        use datafusion::logical_expr::{col, lit, Sort, SortExpr};
+
+        // EmptyRelation: schema (a: Int64, b: Int64)
+        let input_arrow = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+        ]));
+        let input_df = Arc::new(DFSchema::try_from((*input_arrow).clone()).unwrap());
+        let empty = LogicalPlan::EmptyRelation(datafusion::logical_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: input_df,
+        });
+
+        // Projection: (a + b) AS s, a
+        let proj_exprs = vec![(col("a") + col("b")).alias("s"), col("a")];
+        let proj_arrow = Arc::new(Schema::new(vec![
+            Field::new("s", DataType::Int64, true),
+            Field::new("a", DataType::Int64, true),
+        ]));
+        let proj_df = Arc::new(DFSchema::try_from((*proj_arrow).clone()).unwrap());
+        let projection = LogicalPlan::Projection(
+            Projection::try_new_with_schema(proj_exprs, Arc::new(empty), proj_df).unwrap(),
+        );
+
+        // Sort: CASE WHEN s = 0 THEN a END ASC, s ASC
+        // `s` is a projection alias for `a + b`; inside the CASE it must be
+        // replaced with the underlying expression so Postgres can resolve it.
+        let case_expr = Expr::Case(datafusion::logical_expr::Case {
+            expr: None,
+            when_then_expr: vec![(
+                Box::new(col("s").eq(lit(0i64))),
+                Box::new(col("a")),
+            )],
+            else_expr: None,
+        });
+        let sort_arrow = Arc::new(Schema::new(vec![
+            Field::new("s", DataType::Int64, true),
+            Field::new("a", DataType::Int64, true),
+        ]));
+        let sort = LogicalPlan::Sort(Sort {
+            expr: vec![
+                SortExpr { expr: case_expr, asc: true, nulls_first: false },
+                SortExpr { expr: col("s"), asc: true, nulls_first: false },
+            ],
+            input: Arc::new(projection),
+            fetch: None,
+        });
+
+        let executor = TestExecutor {
+            compute_context: "ctx".into(),
+            cannot_federate: None,
+        };
+        let vp = VirtualExecutionPlan::new(
+            sort,
+            Arc::new(executor),
+            Statistics::new_unknown(&sort_arrow),
+        );
+
+        let sql = vp.final_sql().expect("final_sql must succeed");
+
+        // Without the fix the DataFusion unparser leaves the alias as-is inside the CASE:
+        //   ORDER BY CASE WHEN (s = 0) THEN a END ...
+        // PostgreSQL rejects this with SQLSTATE 42703.
+        //
+        // With the fix `inline_sort_projection_aliases` replaces `s` with the underlying
+        // projection expression `a + b` before unparsing:
+        //   ORDER BY CASE WHEN ((a + b) = 0) THEN a END ...
+        assert!(
+            !sql.contains("CASE WHEN (s = 0)"),
+            "final_sql must not emit alias `s` inside CASE WHEN (Postgres 42703 regression); \
+             got:\n{sql}"
+        );
+        assert!(
+            sql.contains("CASE WHEN ((a + b) = 0)"),
+            "ORDER BY CASE must inline the alias to the underlying expression `(a + b)`; \
+             got:\n{sql}"
         );
     }
 }

--- a/datafusion-federation/src/sql/sort_alias_inliner.rs
+++ b/datafusion-federation/src/sql/sort_alias_inliner.rs
@@ -6,16 +6,17 @@
 /// SELECT output column list in two different ways depending on context:
 ///
 /// - A **bare** output-column alias *is* allowed as a top-level sort key:
-///   `ORDER BY "my_alias"` ✅
+///   `ORDER BY "my_alias"`.
 /// - An alias used **inside a compound expression** is **not** resolved against
 ///   the SELECT list — it is resolved against the `FROM` tables only:
-///   `ORDER BY CASE WHEN "my_alias" = 0 THEN ... END` ❌ → `42703`
+///   `ORDER BY CASE WHEN "my_alias" = 0 THEN ... END`.
 ///
 /// DataFusion's unparser (`unproject_sort_expr`) only re-inlines `ScalarFunction`
 /// projection expressions into sort keys. For any other expression shape (e.g. a
 /// `BinaryExpr` like `grouping(a) + grouping(b)`), it falls through and leaves a
 /// bare `Column("alias")` inside compound sort expressions. When this column
-/// reference is not at the top level of the sort key, PostgreSQL cannot resolve it
+/// reference is not at the top level of the sort key, PostgreSQL (and other common
+///  databases) cannot resolve it
 /// and returns `ERROR: column "alias" does not exist (SQLSTATE 42703)`.
 ///
 /// See: <https://www.postgresql.org/docs/current/sql-select.html#SQL-ORDERBY>
@@ -23,17 +24,7 @@
 /// > *output column name* must stand alone, that is, it cannot be used in an
 /// > expression — for example, `ORDER BY foo + 1` is not valid if the output
 /// > column name is `foo`."
-///
-/// # The Fix
-///
-/// Before handing the federated sub-plan to the unparser, walk the plan tree.
-/// When a `Sort` node sits directly above a `Projection` node, examine every
-/// sort expression. Any `Expr::Column` with no relation qualifier that matches a
-/// Projection output alias AND maps to a non-trivial projection expression (i.e.
-/// not itself a plain `Column`) is replaced inline with that underlying expression
-/// (with any alias wrapper stripped). After this substitution the alias name no
-/// longer appears inside compound sort keys, so the SQL the unparser generates is
-/// valid for any standard-compliant SQL engine.
+
 use datafusion::{
     common::{
         tree_node::{Transformed, TreeNode},
@@ -89,7 +80,7 @@ fn inline_aliases_in_sort_expr(
 ) -> Result<datafusion::logical_expr::SortExpr> {
     // If the sort key is already a bare column reference at the top level,
     // leave it as-is: PostgreSQL handles bare output aliases fine.
-    if matches!(&sort_expr.expr, Expr::Column(c) if c.relation.is_none()) {
+    if matches!(&sort_expr.expr, Expr::Column(Column{relation: None,..}))  {
         return Ok(sort_expr);
     }
 
@@ -109,19 +100,13 @@ fn inline_aliases_in_sort_expr(
 /// expression, replace it with that expression (alias-stripped). Otherwise
 /// return `Transformed::no(expr)`.
 fn inline_one_column_ref(expr: Expr, proj: &Projection) -> Result<Transformed<Expr>> {
-    let Expr::Column(ref col) = expr else {
+    let Expr::Column(Column{ relation: None, name, ..}) = &expr else {
         return Ok(Transformed::no(expr));
     };
 
-    // Only rewrite unqualified column references (relation is None).
-    // A qualified reference like `table.col` cannot be a SELECT-list alias.
-    if col.relation.is_some() {
-        return Ok(Transformed::no(expr));
-    }
-
     // Look up the column name in the projection schema to find the
     // corresponding projection expression.
-    if let Ok(idx) = proj.schema.index_of_column(&Column::new_unqualified(&col.name)) {
+    if let Ok(idx) = proj.schema.index_of_column(&Column::new_unqualified(name)) {
         if let Some(proj_expr) = proj.expr.get(idx) {
             let underlying = strip_alias(proj_expr.clone());
             // Only inline if the underlying expression is non-trivial —

--- a/datafusion-federation/src/sql/sort_alias_inliner.rs
+++ b/datafusion-federation/src/sql/sort_alias_inliner.rs
@@ -24,7 +24,6 @@
 /// > *output column name* must stand alone, that is, it cannot be used in an
 /// > expression — for example, `ORDER BY foo + 1` is not valid if the output
 /// > column name is `foo`."
-
 use datafusion::{
     common::{
         tree_node::{Transformed, TreeNode},
@@ -51,7 +50,11 @@ pub fn inline_sort_projection_aliases(plan: LogicalPlan) -> Result<LogicalPlan> 
                 .collect::<Result<Vec<_>>>()?;
 
             if new_exprs == expr {
-                Ok(Transformed::no(LogicalPlan::Sort(Sort { expr, input, fetch })))
+                Ok(Transformed::no(LogicalPlan::Sort(Sort {
+                    expr,
+                    input,
+                    fetch,
+                })))
             } else {
                 Ok(Transformed::yes(LogicalPlan::Sort(Sort {
                     expr: new_exprs,
@@ -80,7 +83,7 @@ fn inline_aliases_in_sort_expr(
 ) -> Result<datafusion::logical_expr::SortExpr> {
     // If the sort key is already a bare column reference at the top level,
     // leave it as-is: PostgreSQL handles bare output aliases fine.
-    if matches!(&sort_expr.expr, Expr::Column(Column{relation: None,..}))  {
+    if matches!(&sort_expr.expr, Expr::Column(Column { relation: None, .. })) {
         return Ok(sort_expr);
     }
 
@@ -100,7 +103,12 @@ fn inline_aliases_in_sort_expr(
 /// expression, replace it with that expression (alias-stripped). Otherwise
 /// return `Transformed::no(expr)`.
 fn inline_one_column_ref(expr: Expr, proj: &Projection) -> Result<Transformed<Expr>> {
-    let Expr::Column(Column{ relation: None, name, ..}) = &expr else {
+    let Expr::Column(Column {
+        relation: None,
+        name,
+        ..
+    }) = &expr
+    else {
         return Ok(Transformed::no(expr));
     };
 
@@ -185,30 +193,30 @@ mod tests {
         });
 
         // Projection: (a + b) AS s, a
-        let proj_exprs = vec![
-            (col("a") + col("b")).alias("s"),
-            col("a"),
-        ];
+        let proj_exprs = vec![(col("a") + col("b")).alias("s"), col("a")];
         let proj_schema = schema_ref(&[("s", DataType::Int64), ("a", DataType::Int64)]);
-        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
-            proj_exprs,
-            Arc::new(empty),
-            proj_schema,
-        ).unwrap());
+        let projection = LogicalPlan::Projection(
+            Projection::try_new_with_schema(proj_exprs, Arc::new(empty), proj_schema).unwrap(),
+        );
 
         // Sort: CASE WHEN s = 0 THEN a END ASC, s ASC
         let case_expr = Expr::Case(datafusion::logical_expr::Case {
             expr: None,
-            when_then_expr: vec![(
-                Box::new(col("s").eq(lit(0i64))),
-                Box::new(col("a")),
-            )],
+            when_then_expr: vec![(Box::new(col("s").eq(lit(0i64))), Box::new(col("a")))],
             else_expr: None,
         });
 
         let sort_exprs = vec![
-            SortExpr { expr: case_expr, asc: true, nulls_first: false },
-            SortExpr { expr: col("s"), asc: true, nulls_first: false },
+            SortExpr {
+                expr: case_expr,
+                asc: true,
+                nulls_first: false,
+            },
+            SortExpr {
+                expr: col("s"),
+                asc: true,
+                nulls_first: false,
+            },
         ];
         let sort = LogicalPlan::Sort(Sort {
             expr: sort_exprs,
@@ -265,7 +273,11 @@ mod tests {
 
         // Sort directly on EmptyRelation (no Projection in between).
         let sort = LogicalPlan::Sort(Sort {
-            expr: vec![SortExpr { expr: col("a"), asc: true, nulls_first: false }],
+            expr: vec![SortExpr {
+                expr: col("a"),
+                asc: true,
+                nulls_first: false,
+            }],
             input: Arc::new(empty),
             fetch: None,
         });
@@ -303,11 +315,9 @@ mod tests {
         // Projection: a AS x, b
         let proj_exprs = vec![col("a").alias("x"), col("b")];
         let proj_schema = schema_ref(&[("x", DataType::Int64), ("b", DataType::Int64)]);
-        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
-            proj_exprs,
-            Arc::new(empty),
-            proj_schema,
-        ).unwrap());
+        let projection = LogicalPlan::Projection(
+            Projection::try_new_with_schema(proj_exprs, Arc::new(empty), proj_schema).unwrap(),
+        );
 
         // Sort: x + 1 — x is a trivial alias of column a, so `x` inside a
         // compound expression is NOT inlined (underlying expr is also a column).
@@ -318,13 +328,19 @@ mod tests {
         });
 
         let sort = LogicalPlan::Sort(Sort {
-            expr: vec![SortExpr { expr: sort_expr, asc: true, nulls_first: false }],
+            expr: vec![SortExpr {
+                expr: sort_expr,
+                asc: true,
+                nulls_first: false,
+            }],
             input: Arc::new(projection),
             fetch: None,
         });
 
         let rewritten = inline_sort_projection_aliases(sort).unwrap();
-        let LogicalPlan::Sort(rs) = &rewritten else { panic!() };
+        let LogicalPlan::Sort(rs) = &rewritten else {
+            panic!()
+        };
         // `x` is a trivial rename of `a`, so inlining would give `a + 1`
         // which is equivalent — but the underlying expr is a Column so
         // our rule deliberately does NOT inline it.
@@ -353,26 +369,29 @@ mod tests {
         // Projection: (a + b) AS s, a
         let proj_exprs = vec![(col("a") + col("b")).alias("s"), col("a")];
         let proj_schema = schema_ref(&[("s", DataType::Int64), ("a", DataType::Int64)]);
-        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
-            proj_exprs,
-            Arc::new(empty),
-            proj_schema,
-        ).unwrap());
+        let projection = LogicalPlan::Projection(
+            Projection::try_new_with_schema(proj_exprs, Arc::new(empty), proj_schema).unwrap(),
+        );
 
         // Sort: CASE WHEN s = 0 THEN a END ASC, s ASC
         let case_expr = Expr::Case(datafusion::logical_expr::Case {
             expr: None,
-            when_then_expr: vec![(
-                Box::new(col("s").eq(lit(0i64))),
-                Box::new(col("a")),
-            )],
+            when_then_expr: vec![(Box::new(col("s").eq(lit(0i64))), Box::new(col("a")))],
             else_expr: None,
         });
 
         let sort = LogicalPlan::Sort(Sort {
             expr: vec![
-                SortExpr { expr: case_expr, asc: true, nulls_first: false },
-                SortExpr { expr: col("s"), asc: true, nulls_first: false },
+                SortExpr {
+                    expr: case_expr,
+                    asc: true,
+                    nulls_first: false,
+                },
+                SortExpr {
+                    expr: col("s"),
+                    asc: true,
+                    nulls_first: false,
+                },
             ],
             input: Arc::new(projection),
             fetch: None,

--- a/datafusion-federation/src/sql/sort_alias_inliner.rs
+++ b/datafusion-federation/src/sql/sort_alias_inliner.rs
@@ -1,0 +1,417 @@
+/// Re-inline projection aliases that appear **inside** `ORDER BY` expressions.
+///
+/// # The Problem
+///
+/// PostgreSQL (and the SQL standard) resolve `ORDER BY` sort keys against the
+/// SELECT output column list in two different ways depending on context:
+///
+/// - A **bare** output-column alias *is* allowed as a top-level sort key:
+///   `ORDER BY "my_alias"` ✅
+/// - An alias used **inside a compound expression** is **not** resolved against
+///   the SELECT list — it is resolved against the `FROM` tables only:
+///   `ORDER BY CASE WHEN "my_alias" = 0 THEN ... END` ❌ → `42703`
+///
+/// DataFusion's unparser (`unproject_sort_expr`) only re-inlines `ScalarFunction`
+/// projection expressions into sort keys. For any other expression shape (e.g. a
+/// `BinaryExpr` like `grouping(a) + grouping(b)`), it falls through and leaves a
+/// bare `Column("alias")` inside compound sort expressions. When this column
+/// reference is not at the top level of the sort key, PostgreSQL cannot resolve it
+/// and returns `ERROR: column "alias" does not exist (SQLSTATE 42703)`.
+///
+/// See: <https://www.postgresql.org/docs/current/sql-select.html#SQL-ORDERBY>
+/// > "Each column can be referenced by name or by number. [...] Note that an
+/// > *output column name* must stand alone, that is, it cannot be used in an
+/// > expression — for example, `ORDER BY foo + 1` is not valid if the output
+/// > column name is `foo`."
+///
+/// # The Fix
+///
+/// Before handing the federated sub-plan to the unparser, walk the plan tree.
+/// When a `Sort` node sits directly above a `Projection` node, examine every
+/// sort expression. Any `Expr::Column` with no relation qualifier that matches a
+/// Projection output alias AND maps to a non-trivial projection expression (i.e.
+/// not itself a plain `Column`) is replaced inline with that underlying expression
+/// (with any alias wrapper stripped). After this substitution the alias name no
+/// longer appears inside compound sort keys, so the SQL the unparser generates is
+/// valid for any standard-compliant SQL engine.
+use datafusion::{
+    common::{
+        tree_node::{Transformed, TreeNode},
+        Column,
+    },
+    error::Result,
+    logical_expr::{Expr, LogicalPlan, Projection, Sort},
+};
+
+/// Walk the entire logical plan and, for every `Sort → Projection` pair,
+/// replace alias column references **inside compound sort expressions** with the
+/// underlying projection expression.  Returns the (possibly rewritten) plan.
+pub fn inline_sort_projection_aliases(plan: LogicalPlan) -> Result<LogicalPlan> {
+    plan.transform(|node| match node {
+        LogicalPlan::Sort(Sort { expr, input, fetch })
+            if matches!(input.as_ref(), LogicalPlan::Projection(_)) =>
+        {
+            let LogicalPlan::Projection(proj) = input.as_ref() else {
+                unreachable!("guarded by matches! above")
+            };
+            let new_exprs = expr
+                .iter()
+                .map(|sort_expr| inline_aliases_in_sort_expr(sort_expr.clone(), proj))
+                .collect::<Result<Vec<_>>>()?;
+
+            if new_exprs == expr {
+                Ok(Transformed::no(LogicalPlan::Sort(Sort { expr, input, fetch })))
+            } else {
+                Ok(Transformed::yes(LogicalPlan::Sort(Sort {
+                    expr: new_exprs,
+                    input,
+                    fetch,
+                })))
+            }
+        }
+        other => Ok(Transformed::no(other)),
+    })
+    .map(|t| t.data)
+}
+
+/// Inline aliases for a single `SortExpr` (which wraps an `Expr`).
+///
+/// If the inner expression is itself a bare `Expr::Column` with no qualifier
+/// (i.e. a potential top-level alias reference), we leave it alone — PostgreSQL
+/// accepts a bare alias as a top-level sort key and re-inlining it would
+/// produce a redundant expression change.
+///
+/// For any other expression shape we walk its sub-expressions and replace any
+/// unqualified column references that map to non-trivial projection aliases.
+fn inline_aliases_in_sort_expr(
+    sort_expr: datafusion::logical_expr::SortExpr,
+    proj: &Projection,
+) -> Result<datafusion::logical_expr::SortExpr> {
+    // If the sort key is already a bare column reference at the top level,
+    // leave it as-is: PostgreSQL handles bare output aliases fine.
+    if matches!(&sort_expr.expr, Expr::Column(c) if c.relation.is_none()) {
+        return Ok(sort_expr);
+    }
+
+    let inlined = sort_expr
+        .expr
+        .transform(|e| inline_one_column_ref(e, proj))?
+        .data;
+
+    Ok(datafusion::logical_expr::SortExpr {
+        expr: inlined,
+        asc: sort_expr.asc,
+        nulls_first: sort_expr.nulls_first,
+    })
+}
+
+/// If `expr` is an unqualified `Column` that maps to a non-trivial projection
+/// expression, replace it with that expression (alias-stripped). Otherwise
+/// return `Transformed::no(expr)`.
+fn inline_one_column_ref(expr: Expr, proj: &Projection) -> Result<Transformed<Expr>> {
+    let Expr::Column(ref col) = expr else {
+        return Ok(Transformed::no(expr));
+    };
+
+    // Only rewrite unqualified column references (relation is None).
+    // A qualified reference like `table.col` cannot be a SELECT-list alias.
+    if col.relation.is_some() {
+        return Ok(Transformed::no(expr));
+    }
+
+    // Look up the column name in the projection schema to find the
+    // corresponding projection expression.
+    if let Ok(idx) = proj.schema.index_of_column(&Column::new_unqualified(&col.name)) {
+        if let Some(proj_expr) = proj.expr.get(idx) {
+            let underlying = strip_alias(proj_expr.clone());
+            // Only inline if the underlying expression is non-trivial —
+            // a plain column-to-column rename does not need inlining.
+            if !matches!(underlying, Expr::Column(_)) {
+                return Ok(Transformed::yes(underlying));
+            }
+        }
+    }
+
+    Ok(Transformed::no(expr))
+}
+
+/// Strip any top-level `Alias` wrapper(s) from an expression, returning the
+/// innermost non-alias expression.
+fn strip_alias(expr: Expr) -> Expr {
+    match expr {
+        Expr::Alias(alias) => strip_alias(*alias.expr),
+        other => other,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::{
+        arrow::datatypes::{DataType, Field, Schema},
+        common::{DFSchema, DFSchemaRef},
+        logical_expr::{col, lit, Expr, LogicalPlan, Projection, Sort, SortExpr},
+        sql::unparser::{dialect::DefaultDialect, Unparser},
+    };
+
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    fn schema_ref(fields: &[(&str, DataType)]) -> DFSchemaRef {
+        let arrow_schema = Schema::new(
+            fields
+                .iter()
+                .map(|(name, dt)| Field::new(*name, dt.clone(), true))
+                .collect::<Vec<_>>(),
+        );
+        Arc::new(DFSchema::try_from(arrow_schema).unwrap())
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1: alias inside a CASE expression in ORDER BY is inlined
+    // ------------------------------------------------------------------
+
+    /// Build a plan shaped like:
+    ///
+    /// ```text
+    /// Sort: [CASE WHEN s = 0 THEN a END ASC, s ASC]
+    ///   Projection: (a + b) AS s, a
+    ///     EmptyRelation (schema: a: Int64, b: Int64)
+    /// ```
+    ///
+    /// The `s` in the CASE expression is an alias for `a + b`.  After
+    /// inlining, the sort expression should reference `a + b` directly,
+    /// not the alias `s`.
+    #[test]
+    fn alias_inside_case_is_inlined() {
+        let input_schema = schema_ref(&[("a", DataType::Int64), ("b", DataType::Int64)]);
+
+        let empty = LogicalPlan::EmptyRelation(datafusion::logical_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::clone(&input_schema),
+        });
+
+        // Projection: (a + b) AS s, a
+        let proj_exprs = vec![
+            (col("a") + col("b")).alias("s"),
+            col("a"),
+        ];
+        let proj_schema = schema_ref(&[("s", DataType::Int64), ("a", DataType::Int64)]);
+        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
+            proj_exprs,
+            Arc::new(empty),
+            proj_schema,
+        ).unwrap());
+
+        // Sort: CASE WHEN s = 0 THEN a END ASC, s ASC
+        let case_expr = Expr::Case(datafusion::logical_expr::Case {
+            expr: None,
+            when_then_expr: vec![(
+                Box::new(col("s").eq(lit(0i64))),
+                Box::new(col("a")),
+            )],
+            else_expr: None,
+        });
+
+        let sort_exprs = vec![
+            SortExpr { expr: case_expr, asc: true, nulls_first: false },
+            SortExpr { expr: col("s"), asc: true, nulls_first: false },
+        ];
+        let sort = LogicalPlan::Sort(Sort {
+            expr: sort_exprs,
+            input: Arc::new(projection),
+            fetch: None,
+        });
+
+        let rewritten = inline_sort_projection_aliases(sort).unwrap();
+
+        let LogicalPlan::Sort(rewritten_sort) = &rewritten else {
+            panic!("expected Sort at root");
+        };
+
+        // The CASE expression's `s` should have been replaced with `(a + b)`.
+        // The top-level bare `s` should remain unchanged.
+        let case_sort = &rewritten_sort.expr[0].expr;
+        let bare_sort = &rewritten_sort.expr[1].expr;
+
+        // Bare alias `s` at the top level → NOT rewritten.
+        assert!(
+            matches!(bare_sort, Expr::Column(c) if c.name == "s"),
+            "Top-level bare alias column must NOT be inlined; got: {bare_sort:?}"
+        );
+
+        // `s` inside CASE → must be rewritten to `a + b`.
+        let case_str = format!("{case_sort:?}");
+        assert!(
+            !case_str.contains("Column(Column { relation: None, name: \"s\" })"),
+            "Alias `s` must not remain inside CASE; got: {case_sort:?}"
+        );
+        // The `s` inside the CASE when-expr should now be the BinaryExpr (a + b).
+        let Expr::Case(case) = case_sort else {
+            panic!("expected CASE at sort key 0; got: {case_sort:?}");
+        };
+        let when_cond = &case.when_then_expr[0].0;
+        // when_cond should be `(a + b) = 0`, not `s = 0`
+        assert!(
+            !matches!(when_cond.as_ref(), Expr::Column(c) if c.name == "s"),
+            "The WHEN condition must not be a bare `s` column; got: {when_cond:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: no rewrite when Sort is not directly above a Projection
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn no_rewrite_without_projection_child() {
+        let input_schema = schema_ref(&[("a", DataType::Int64)]);
+        let empty = LogicalPlan::EmptyRelation(datafusion::logical_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::clone(&input_schema),
+        });
+
+        // Sort directly on EmptyRelation (no Projection in between).
+        let sort = LogicalPlan::Sort(Sort {
+            expr: vec![SortExpr { expr: col("a"), asc: true, nulls_first: false }],
+            input: Arc::new(empty),
+            fetch: None,
+        });
+
+        // Clone for comparison.
+        let original_exprs = match &sort {
+            LogicalPlan::Sort(s) => s.expr.clone(),
+            _ => panic!(),
+        };
+
+        let rewritten = inline_sort_projection_aliases(sort).unwrap();
+        let rewritten_exprs = match &rewritten {
+            LogicalPlan::Sort(s) => s.expr.clone(),
+            _ => panic!(),
+        };
+
+        assert_eq!(
+            original_exprs, rewritten_exprs,
+            "Sort with no Projection child must not be modified"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: plain column alias is NOT inlined (it's a trivial rename)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn trivial_column_alias_not_inlined() {
+        let input_schema = schema_ref(&[("a", DataType::Int64), ("b", DataType::Int64)]);
+        let empty = LogicalPlan::EmptyRelation(datafusion::logical_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::clone(&input_schema),
+        });
+
+        // Projection: a AS x, b
+        let proj_exprs = vec![col("a").alias("x"), col("b")];
+        let proj_schema = schema_ref(&[("x", DataType::Int64), ("b", DataType::Int64)]);
+        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
+            proj_exprs,
+            Arc::new(empty),
+            proj_schema,
+        ).unwrap());
+
+        // Sort: x + 1 — x is a trivial alias of column a, so `x` inside a
+        // compound expression is NOT inlined (underlying expr is also a column).
+        let sort_expr = Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr {
+            left: Box::new(col("x")),
+            op: datafusion::logical_expr::Operator::Plus,
+            right: Box::new(lit(1i64)),
+        });
+
+        let sort = LogicalPlan::Sort(Sort {
+            expr: vec![SortExpr { expr: sort_expr, asc: true, nulls_first: false }],
+            input: Arc::new(projection),
+            fetch: None,
+        });
+
+        let rewritten = inline_sort_projection_aliases(sort).unwrap();
+        let LogicalPlan::Sort(rs) = &rewritten else { panic!() };
+        // `x` is a trivial rename of `a`, so inlining would give `a + 1`
+        // which is equivalent — but the underlying expr is a Column so
+        // our rule deliberately does NOT inline it.
+        let sort_key_str = format!("{:?}", rs.expr[0].expr);
+        assert!(
+            sort_key_str.contains("\"x\""),
+            "Trivial column alias must NOT be inlined; got: {sort_key_str}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: end-to-end SQL generation does not contain alias in ORDER BY
+    // ------------------------------------------------------------------
+
+    /// Verifies that after `inline_sort_projection_aliases` the SQL produced by
+    /// the DataFusion unparser does not contain the alias name inside a CASE in
+    /// the ORDER BY clause.
+    #[test]
+    fn unparsed_sql_does_not_use_alias_inside_order_by_case() {
+        let input_schema = schema_ref(&[("a", DataType::Int64), ("b", DataType::Int64)]);
+        let empty = LogicalPlan::EmptyRelation(datafusion::logical_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::clone(&input_schema),
+        });
+
+        // Projection: (a + b) AS s, a
+        let proj_exprs = vec![(col("a") + col("b")).alias("s"), col("a")];
+        let proj_schema = schema_ref(&[("s", DataType::Int64), ("a", DataType::Int64)]);
+        let projection = LogicalPlan::Projection(Projection::try_new_with_schema(
+            proj_exprs,
+            Arc::new(empty),
+            proj_schema,
+        ).unwrap());
+
+        // Sort: CASE WHEN s = 0 THEN a END ASC, s ASC
+        let case_expr = Expr::Case(datafusion::logical_expr::Case {
+            expr: None,
+            when_then_expr: vec![(
+                Box::new(col("s").eq(lit(0i64))),
+                Box::new(col("a")),
+            )],
+            else_expr: None,
+        });
+
+        let sort = LogicalPlan::Sort(Sort {
+            expr: vec![
+                SortExpr { expr: case_expr, asc: true, nulls_first: false },
+                SortExpr { expr: col("s"), asc: true, nulls_first: false },
+            ],
+            input: Arc::new(projection),
+            fetch: None,
+        });
+
+        let rewritten = inline_sort_projection_aliases(sort).unwrap();
+
+        let dialect = DefaultDialect {};
+        let sql = Unparser::new(&dialect)
+            .plan_to_sql(&rewritten)
+            .unwrap()
+            .to_string();
+
+        // The alias `s` must NOT appear inside the CASE expression in ORDER BY.
+        // A bare `s` at the top level of ORDER BY is acceptable (Postgres allows it),
+        // but the CASE WHEN condition should reference `(a + b)` directly.
+        assert!(
+            !sql.contains("CASE WHEN s = 0") && !sql.contains("CASE WHEN \"s\" = 0"),
+            "Generated SQL must not use alias `s` inside CASE in ORDER BY; got:\n{sql}"
+        );
+        // The SQL should still contain a CASE expression.
+        assert!(
+            sql.to_uppercase().contains("CASE"),
+            "Expected CASE in ORDER BY; got:\n{sql}"
+        );
+    }
+}

--- a/datafusion-federation/tests/postgres_federation.rs
+++ b/datafusion-federation/tests/postgres_federation.rs
@@ -1,0 +1,389 @@
+/// Integration test: sort alias in CASE ORDER BY against a real Postgres database.
+///
+/// # Bug being tested
+///
+/// DataFusion's SQL federation generates queries of the form:
+///
+/// ```sql
+/// ORDER BY CASE WHEN ("lochierarchy" = 0) THEN "category" END ASC NULLS LAST
+/// ```
+///
+/// where `lochierarchy` is a SELECT-list alias for `grouping(category) + grouping(class)`.
+/// PostgreSQL rejects this with SQLSTATE 42703 ("column lochierarchy does not exist") because
+/// it does not resolve SELECT-list aliases inside compound ORDER BY expressions.
+///
+/// # Fix
+///
+/// `datafusion_federation::sql`'s `inline_sort_projection_aliases` rewrites the ORDER BY
+/// expression before unparsing, substituting the alias definition in place of the alias
+/// reference. Without that rewrite this test would fail with a Postgres 42703 error.
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::{
+    arrow::{
+        array::{
+            ArrayRef, BooleanArray, Float32Array, Float64Array, Int32Array, Int64Array,
+            StringArray,
+        },
+        datatypes::{DataType, Field, Schema, SchemaRef},
+        error::ArrowError,
+        record_batch::RecordBatch,
+    },
+    error::{DataFusionError, Result as DfResult},
+    execution::{context::SessionContext, session_state::SessionStateBuilder},
+    optimizer::{
+        analyzer::{
+            resolve_grouping_function::ResolveGroupingFunction, type_coercion::TypeCoercion,
+        },
+        AnalyzerRule,
+    },
+    physical_plan::{stream::RecordBatchStreamAdapter, PhysicalExpr, SendableRecordBatchStream},
+    sql::unparser::dialect::Dialect,
+};
+use datafusion_federation::{
+    sql::{
+        federation_analyzer_rule, RemoteTable, RemoteTableRef, SQLExecutor, SQLFederationProvider,
+        SQLTableSource,
+    },
+    FederatedQueryPlanner, FederatedTableProviderAdaptor,
+};
+use futures::stream;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, NoTls, Row};
+
+// ---------------------------------------------------------------------------
+// PostgresExecutor
+// ---------------------------------------------------------------------------
+
+struct PostgresExecutor {
+    client: Arc<Mutex<Client>>,
+    connection_string: String,
+}
+
+impl std::fmt::Debug for PostgresExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresExecutor")
+            .field("connection_string", &self.connection_string)
+            .finish()
+    }
+}
+
+impl PostgresExecutor {
+    async fn connect(conn_str: &str) -> anyhow::Result<Self> {
+        let (client, connection) = tokio_postgres::connect(conn_str, NoTls).await?;
+
+        // Spawn the connection task; it runs until the client is dropped.
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("postgres connection error: {e}");
+            }
+        });
+
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+            connection_string: conn_str.to_string(),
+        })
+    }
+
+    async fn execute_ddl(&self, sql: &str) -> anyhow::Result<()> {
+        self.client.lock().await.execute(sql, &[]).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SQLExecutor for PostgresExecutor {
+    fn name(&self) -> &str {
+        "postgres"
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        Some(self.connection_string.clone())
+    }
+
+    fn dialect(&self) -> Arc<dyn Dialect> {
+        Arc::new(datafusion::sql::unparser::dialect::PostgreSqlDialect {})
+    }
+
+    fn execute(
+        &self,
+        query: &str,
+        schema: SchemaRef,
+        _filters: &[Arc<dyn PhysicalExpr>],
+    ) -> DfResult<SendableRecordBatchStream> {
+        let client = Arc::clone(&self.client);
+        let query = query.to_string();
+        let schema_clone = Arc::clone(&schema);
+
+        let fut = async move {
+            let locked = client.lock().await;
+            let rows = locked
+                .query(&query, &[])
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+            pg_rows_to_batch(&rows, &schema_clone)
+        };
+
+        let stream = stream::once(fut);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    async fn table_names(&self) -> DfResult<Vec<String>> {
+        let locked = self.client.lock().await;
+        let rows = locked
+            .query(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+                &[],
+            )
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| r.get::<_, String>(0))
+            .collect())
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> DfResult<SchemaRef> {
+        let locked = self.client.lock().await;
+        let rows = locked
+            .query(
+                "SELECT column_name, data_type \
+                 FROM information_schema.columns \
+                 WHERE table_schema = 'public' AND table_name = $1 \
+                 ORDER BY ordinal_position",
+                &[&table_name],
+            )
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+        let fields: Vec<Field> = rows
+            .iter()
+            .map(|row| {
+                let col_name: String = row.get(0);
+                let pg_type: String = row.get(1);
+                Field::new(col_name, pg_data_type(&pg_type), true)
+            })
+            .collect();
+
+        Ok(Arc::new(Schema::new(fields)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+fn pg_data_type(pg_type: &str) -> DataType {
+    match pg_type {
+        "text" | "character varying" | "character" | "varchar" => DataType::Utf8,
+        "integer" | "int" | "int4" => DataType::Int32,
+        "bigint" | "int8" => DataType::Int64,
+        "double precision" | "float8" => DataType::Float64,
+        "real" | "float4" => DataType::Float32,
+        "boolean" | "bool" => DataType::Boolean,
+        "numeric" | "decimal" => DataType::Float64,
+        _ => DataType::Utf8,
+    }
+}
+
+fn pg_rows_to_batch(rows: &[Row], schema: &SchemaRef) -> DfResult<RecordBatch> {
+    let columns: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(col_idx, field)| -> DfResult<ArrayRef> {
+            match field.data_type() {
+                DataType::Utf8 => {
+                    let vals: Vec<Option<String>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<String>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(StringArray::from(vals)) as ArrayRef)
+                }
+                DataType::Int32 => {
+                    let vals: Vec<Option<i32>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<i32>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(Int32Array::from(vals)) as ArrayRef)
+                }
+                DataType::Int64 => {
+                    let vals: Vec<Option<i64>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<i64>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(Int64Array::from(vals)) as ArrayRef)
+                }
+                DataType::Float64 => {
+                    let vals: Vec<Option<f64>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<f64>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(Float64Array::from(vals)) as ArrayRef)
+                }
+                DataType::Float32 => {
+                    let vals: Vec<Option<f32>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<f32>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(Float32Array::from(vals)) as ArrayRef)
+                }
+                DataType::Boolean => {
+                    let vals: Vec<Option<bool>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<bool>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(BooleanArray::from(vals)) as ArrayRef)
+                }
+                _ => {
+                    // Fallback: treat any unknown type as Utf8
+                    let vals: Vec<Option<String>> = rows
+                        .iter()
+                        .map(|r| r.try_get::<_, Option<String>>(col_idx).unwrap_or(None))
+                        .collect();
+                    Ok(Arc::new(StringArray::from(vals)) as ArrayRef)
+                }
+            }
+        })
+        .collect::<DfResult<_>>()?;
+
+    RecordBatch::try_new(Arc::clone(schema), columns)
+        .map_err(|e: ArrowError| DataFusionError::from(e))
+}
+
+fn make_session_context() -> SessionContext {
+    let analyzer_rules: Vec<Arc<dyn AnalyzerRule + Send + Sync>> = vec![
+        Arc::new(federation_analyzer_rule()),
+        Arc::new(ResolveGroupingFunction::new()),
+        Arc::new(TypeCoercion::new()),
+    ];
+
+    let state = SessionStateBuilder::new()
+        .with_query_planner(Arc::new(FederatedQueryPlanner::new()))
+        .with_analyzer_rules(analyzer_rules)
+        .with_default_features()
+        .build();
+
+    SessionContext::new_with_state(state)
+}
+
+fn register_table(
+    ctx: &SessionContext,
+    name: &str,
+    executor: Arc<PostgresExecutor>,
+    schema: SchemaRef,
+) -> DfResult<()> {
+    let table_ref = RemoteTableRef::try_from(name.to_string())
+        .map_err(|e| DataFusionError::Plan(format!("invalid table ref '{name}': {e}")))?;
+    let table = Arc::new(RemoteTable::new(table_ref, schema));
+    let provider = Arc::new(SQLFederationProvider::new(executor));
+    let table_source = Arc::new(SQLTableSource::new_with_table(provider, table));
+    let federated_provider = Arc::new(FederatedTableProviderAdaptor::new(table_source));
+    ctx.register_table(name, federated_provider)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sort_alias_in_case_order_by_succeeds_against_postgres() {
+    // Start a Postgres container via testcontainers.
+    let pg = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let port = pg.get_host_port_ipv4(5432).await.unwrap();
+    let conn_str = format!(
+        "host=localhost port={port} user=postgres password=postgres dbname=postgres"
+    );
+
+    let executor = Arc::new(
+        PostgresExecutor::connect(&conn_str)
+            .await
+            .expect("failed to connect to Postgres"),
+    );
+
+    // Create a minimal table shaped like the TPC-DS items table used in q86.
+    executor
+        .execute_ddl(
+            "CREATE TABLE items (
+                category TEXT,
+                class    TEXT,
+                amount   DOUBLE PRECISION
+            )",
+        )
+        .await
+        .expect("CREATE TABLE failed");
+
+    // Insert rows that cover multiple categories / classes so ROLLUP produces
+    // meaningful grouping levels (including the grand total).
+    for (cat, cls, amt) in [
+        ("Electronics", "Phones", 100.0_f64),
+        ("Electronics", "Laptops", 200.0_f64),
+        ("Clothing", "Shirts", 50.0_f64),
+        ("Clothing", "Pants", 75.0_f64),
+    ] {
+        executor
+            .execute_ddl(&format!(
+                "INSERT INTO items (category, class, amount) VALUES ('{cat}', '{cls}', {amt})"
+            ))
+            .await
+            .expect("INSERT failed");
+    }
+
+    // Register the table in a federated DataFusion session context.
+    let ctx = make_session_context();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("category", DataType::Utf8, true),
+        Field::new("class", DataType::Utf8, true),
+        Field::new("amount", DataType::Float64, true),
+    ]));
+    register_table(&ctx, "items", Arc::clone(&executor), schema)
+        .expect("failed to register table");
+
+    // TPC-DS q86-shaped query: ORDER BY uses a CASE expression whose condition
+    // references the SELECT-list alias `lochierarchy`.  Without
+    // `inline_sort_projection_aliases` the federation layer would emit:
+    //
+    //   ORDER BY CASE WHEN ("lochierarchy" = 0) THEN "category" END
+    //
+    // and Postgres would reject it with SQLSTATE 42703 because the alias is not
+    // visible inside the CASE.  With the fix the alias definition is inlined:
+    //
+    //   ORDER BY CASE WHEN ((grouping("category") + grouping("class")) = 0)
+    //                 THEN "category" END
+    let sql = "
+        SELECT
+            sum(amount)                                AS total_sum,
+            category,
+            class,
+            (grouping(category) + grouping(class))    AS lochierarchy
+        FROM items
+        GROUP BY ROLLUP(category, class)
+        ORDER BY
+            lochierarchy DESC NULLS FIRST,
+            CASE WHEN lochierarchy = 0 THEN category END ASC NULLS LAST
+        LIMIT 10
+    ";
+
+    let result = ctx
+        .sql(sql)
+        .await
+        .expect("sql() failed")
+        .collect()
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "Query failed — Postgres SQLSTATE 42703 regression (sort alias not inlined): {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary
- DataFusion unparser adds aliases from the `SELECT` into the `ORDER BY` expressions. This causes issues for complex `ORDER BY` expressions in several common databases (e.g. Postgres).

**DF Unparser output**
```
SELECT (grouping(category) + grouping(class)) AS lochierarchy
FROM t1
ORDER BY CASE WHEN ("lochierarchy" = 0) THEN "category" END
```

**After `sort_alias_inliner::inline_sort_projection_aliases`**
```
SELECT (grouping(category) + grouping(class)) AS lochierarchy
FROM t1
ORDER BY CASE WHEN ((grouping(category) + grouping(class)) = 0) THEN "category" END
```

- Adds a unit regression test and a Postgres integration test (via testcontainers)
